### PR TITLE
Improve Support Dialog UX

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,6 +115,7 @@ class _AuthWrapperState extends State<AuthWrapper> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final authProvider = Provider.of<AuthProvider>(context);
+    final storageService = Provider.of<StorageService>(context, listen: false);
     final currentState = authProvider.state;
 
     // Show support dialog when transitioning to authenticated state
@@ -122,13 +123,16 @@ class _AuthWrapperState extends State<AuthWrapper> {
         currentState == AuthState.authenticated &&
         !_hasShownDialog) {
       _hasShownDialog = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
         if (mounted) {
-          showDialog(
-            context: context,
-            barrierDismissible: false,
-            builder: (context) => const SupportDialog(),
-          );
+          final shouldHide = await storageService.getHideSupportDialog();
+          if (!shouldHide && mounted) {
+            showDialog(
+              context: context,
+              barrierDismissible: false,
+              builder: (context) => const SupportDialog(),
+            );
+          }
         }
       });
     }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -9,6 +9,7 @@ class StorageService {
   static const String _queueIndexKey = 'queue_index';
   static const String _shuffleModeKey = 'shuffle_mode';
   static const String _repeatModeKey = 'repeat_mode';
+  static const String _hideSupportDialogKey = 'hide_support_dialog';
 
   Future<SharedPreferences> get _prefs => SharedPreferences.getInstance();
 
@@ -84,6 +85,16 @@ class StorageService {
   Future<int> getRepeatMode() async {
     final prefs = await _prefs;
     return prefs.getInt(_repeatModeKey) ?? 0;
+  }
+
+  Future<void> saveHideSupportDialog(bool hide) async {
+    final prefs = await _prefs;
+    await prefs.setBool(_hideSupportDialogKey, hide);
+  }
+
+  Future<bool> getHideSupportDialog() async {
+    final prefs = await _prefs;
+    return prefs.getBool(_hideSupportDialogKey) ?? false;
   }
 
   Future<void> clearAll() async {

--- a/lib/widgets/support_dialog.dart
+++ b/lib/widgets/support_dialog.dart
@@ -1,7 +1,8 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../services/services.dart';
 
 class SupportDialog extends StatefulWidget {
   const SupportDialog({super.key});
@@ -11,32 +12,7 @@ class SupportDialog extends StatefulWidget {
 }
 
 class _SupportDialogState extends State<SupportDialog> {
-  bool _canClose = false;
-  int _remainingSeconds = 5;
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-    _startTimer();
-  }
-
-  void _startTimer() {
-    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_remainingSeconds > 0) {
-        setState(() => _remainingSeconds--);
-      } else {
-        setState(() => _canClose = true);
-        timer.cancel();
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
+  bool _doNotShowAgain = false;
 
   Future<void> _launchUrl(String url) async {
     final uri = Uri.parse(url);
@@ -66,12 +42,13 @@ class _SupportDialogState extends State<SupportDialog> {
       child: Container(
         constraints: const BoxConstraints(maxWidth: 500),
         padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Header
-            Row(
-              children: [
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Header
+              Row(
+                children: [
                 Icon(Icons.favorite_rounded, color: Colors.red, size: 28),
                 const SizedBox(width: 12),
                 Expanded(
@@ -84,29 +61,10 @@ class _SupportDialogState extends State<SupportDialog> {
                     ),
                   ),
                 ),
-                if (_canClose)
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.of(context).pop(),
-                  )
-                else
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Colors.grey.withOpacity(0.2),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Text(
-                      '$_remainingSeconds',
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16,
-                      ),
-                    ),
-                  ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
               ],
             ),
 
@@ -219,16 +177,36 @@ class _SupportDialogState extends State<SupportDialog> {
 
             const SizedBox(height: 16),
 
-            Text(
-              'Your support helps keep development going! 🚀',
-              style: TextStyle(
-                fontSize: 12,
-                color: Colors.grey[600],
-                fontStyle: FontStyle.italic,
-              ),
-              textAlign: TextAlign.center,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Checkbox(
+                  value: _doNotShowAgain,
+                  onChanged: (value) {
+                    setState(() {
+                      _doNotShowAgain = value ?? false;
+                    });
+                    Provider.of<StorageService>(
+                      context,
+                      listen: false,
+                    ).saveHideSupportDialog(_doNotShowAgain);
+                  },
+                ),
+                const Text("Don't show again"),
+              ],
             ),
-          ],
+
+              Text(
+                'Your support helps keep development going! 🚀',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey[600],
+                  fontStyle: FontStyle.italic,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musly/services/storage_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('StorageService', () {
+    late StorageService storageService;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      storageService = StorageService();
+    });
+
+    test('saveHideSupportDialog saves value', () async {
+      await storageService.saveHideSupportDialog(true);
+      expect(await storageService.getHideSupportDialog(), true);
+    });
+
+    test('getHideSupportDialog returns false by default', () async {
+      expect(await storageService.getHideSupportDialog(), false);
+    });
+
+    test('saveHideSupportDialog updates value', () async {
+      await storageService.saveHideSupportDialog(true);
+      expect(await storageService.getHideSupportDialog(), true);
+      await storageService.saveHideSupportDialog(false);
+      expect(await storageService.getHideSupportDialog(), false);
+    });
+  });
+}

--- a/test/widgets/support_dialog_test.dart
+++ b/test/widgets/support_dialog_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musly/widgets/support_dialog.dart';
+import 'package:musly/services/storage_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('SupportDialog', () {
+    late StorageService storageService;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      storageService = StorageService();
+    });
+
+    testWidgets('shows checkbox and close button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Provider<StorageService>.value(
+            value: storageService,
+            child: const SupportDialog(),
+          ),
+        ),
+      );
+
+      // Verify close button is present
+      expect(find.byIcon(Icons.close), findsOneWidget);
+
+      // Verify checkbox is present
+      final checkboxFinder = find.byType(Checkbox);
+      await tester.ensureVisible(checkboxFinder);
+      expect(find.text("Don't show again"), findsOneWidget);
+      expect(checkboxFinder, findsOneWidget);
+    });
+
+    testWidgets('toggling checkbox saves preference', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Provider<StorageService>.value(
+            value: storageService,
+            child: const SupportDialog(),
+          ),
+        ),
+      );
+
+      final checkboxFinder = find.byType(Checkbox);
+
+      // Ensure the checkbox is visible by scrolling if necessary
+      await tester.ensureVisible(checkboxFinder);
+      await tester.pumpAndSettle();
+
+      // Check the checkbox
+      await tester.tap(checkboxFinder);
+      await tester.pump();
+
+      // Verify it was saved
+      expect(await storageService.getHideSupportDialog(), true);
+    });
+  });
+}


### PR DESCRIPTION
Improved the user experience of the Support/Donation dialog by removing the forced wait time and allowing users to permanently dismiss the dialog. Implemented preference persistence using `StorageService`.

---
*PR created automatically by Jules for task [6519695095597308202](https://jules.google.com/task/6519695095597308202) started by @dddevid*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Don't show again" option to the support dialog with persistent storage of user preference.

* **Bug Fixes**
  * Close button is now always available on the support dialog.
  * Support dialog content is now scrollable to prevent overflow issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->