### PR TITLE
Use system trust store

### DIFF
--- a/lib/services/subsonic_service.dart
+++ b/lib/services/subsonic_service.dart
@@ -59,7 +59,7 @@ class SubsonicService {
     if (hasCustomServerCert || allowSelfSigned || hasClientCert) {
       (_dio.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () {
         try {
-          final context = SecurityContext();
+          final context = SecurityContext(withTrustedRoots: true);
 
           // Server CA certificate (for verifying the server identity)
           if (hasCustomServerCert) {
@@ -820,3 +820,4 @@ class SearchResult {
 
   bool get isEmpty => artists.isEmpty && albums.isEmpty && songs.isEmpty;
 }
+


### PR DESCRIPTION
Currently the Dio does not use system trust store. This pull request fixes that. Tested on Linux and is working fine.