### PR TITLE
feat: multi-artist support with Navidrome

### DIFF
--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -59,6 +59,8 @@ class Album {
       'year': year,
       'genre': genre,
       'created': created?.toIso8601String(),
+      if (artistParticipants != null)
+        'artists': artistParticipants!.map((a) => a.toJson()).toList(),
     };
   }
 

--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -1,3 +1,5 @@
+import 'artist_ref.dart';
+
 class Album {
   final String id;
   final String name;
@@ -10,6 +12,7 @@ class Album {
   final String? genre;
   final DateTime? created;
   final bool isLocal;
+  final List<ArtistRef>? artistParticipants;
 
   Album({
     required this.id,
@@ -23,6 +26,7 @@ class Album {
     this.genre,
     this.created,
     this.isLocal = false,
+    this.artistParticipants,
   });
 
   factory Album.fromJson(Map<String, dynamic> json) {
@@ -39,6 +43,7 @@ class Album {
       created: json['created'] != null
           ? DateTime.tryParse(json['created'].toString())
           : null,
+      artistParticipants: ArtistRef.parseList(json['artists']),
     );
   }
 

--- a/lib/models/artist_ref.dart
+++ b/lib/models/artist_ref.dart
@@ -3,17 +3,32 @@
 class ArtistRef {
   final String id;
   final String name;
+  /// Explicit cover art ID from the API response. When absent, falls back to
+  /// [id] for servers (like Navidrome) that serve artist images via
+  /// `getCoverArt?id={artistId}`.
+  final String? coverArt;
 
-  const ArtistRef({required this.id, required this.name});
+  const ArtistRef({required this.id, required this.name, this.coverArt});
+
+  /// Cover art ID for `getCoverArt`: explicit [coverArt] if set, otherwise [id].
+  String? get effectiveCoverArt {
+    if (coverArt != null && coverArt!.isNotEmpty) return coverArt;
+    return id.isNotEmpty ? id : null;
+  }
 
   factory ArtistRef.fromJson(Map<String, dynamic> json) {
     return ArtistRef(
       id: json['id']?.toString() ?? '',
       name: json['name']?.toString() ?? '',
+      coverArt: json['coverArt']?.toString(),
     );
   }
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name};
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'name': name,
+    if (coverArt != null) 'coverArt': coverArt,
+  };
 
   static List<ArtistRef>? parseList(dynamic data) {
     if (data == null || data is! List) return null;

--- a/lib/models/artist_ref.dart
+++ b/lib/models/artist_ref.dart
@@ -1,0 +1,27 @@
+/// A lightweight artist reference parsed from Navidrome's `participants` field.
+/// Standard Subsonic servers do not provide this field, so it is always optional.
+class ArtistRef {
+  final String id;
+  final String name;
+
+  const ArtistRef({required this.id, required this.name});
+
+  factory ArtistRef.fromJson(Map<String, dynamic> json) {
+    return ArtistRef(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'id': id, 'name': name};
+
+  static List<ArtistRef>? parseList(dynamic data) {
+    if (data == null || data is! List) return null;
+    final list = data
+        .whereType<Map<String, dynamic>>()
+        .map((e) => ArtistRef.fromJson(e))
+        .where((a) => a.id.isNotEmpty || a.name.isNotEmpty)
+        .toList();
+    return list.isEmpty ? null : list;
+  }
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,4 +1,5 @@
 export 'artist.dart';
+export 'artist_ref.dart';
 export 'album.dart';
 export 'song.dart';
 export 'playlist.dart';

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -109,6 +109,8 @@ class Song {
         if (replayGainTrackPeak != null) 'trackPeak': replayGainTrackPeak,
         if (replayGainAlbumPeak != null) 'albumPeak': replayGainAlbumPeak,
       },
+      if (artistParticipants != null)
+        'artists': artistParticipants!.map((a) => a.toJson()).toList(),
     };
   }
 

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -1,3 +1,5 @@
+import 'artist_ref.dart';
+
 class Song {
   final String id;
   final String title;
@@ -22,6 +24,7 @@ class Song {
   final double? replayGainAlbumGain;
   final double? replayGainTrackPeak;
   final double? replayGainAlbumPeak;
+  final List<ArtistRef>? artistParticipants;
 
   Song({
     required this.id,
@@ -47,10 +50,10 @@ class Song {
     this.replayGainAlbumGain,
     this.replayGainTrackPeak,
     this.replayGainAlbumPeak,
+    this.artistParticipants,
   });
 
   factory Song.fromJson(Map<String, dynamic> json) {
-    
     final replayGain = json['replayGain'] as Map<String, dynamic>?;
 
     return Song(
@@ -77,6 +80,7 @@ class Song {
       replayGainAlbumGain: (replayGain?['albumGain'] as num?)?.toDouble(),
       replayGainTrackPeak: (replayGain?['trackPeak'] as num?)?.toDouble(),
       replayGainAlbumPeak: (replayGain?['albumPeak'] as num?)?.toDouble(),
+      artistParticipants: ArtistRef.parseList(json['artists']),
     );
   }
 
@@ -139,6 +143,7 @@ class Song {
     double? replayGainAlbumGain,
     double? replayGainTrackPeak,
     double? replayGainAlbumPeak,
+    List<ArtistRef>? artistParticipants,
   }) {
     return Song(
       id: id ?? this.id,
@@ -164,6 +169,7 @@ class Song {
       replayGainAlbumGain: replayGainAlbumGain ?? this.replayGainAlbumGain,
       replayGainTrackPeak: replayGainTrackPeak ?? this.replayGainTrackPeak,
       replayGainAlbumPeak: replayGainAlbumPeak ?? this.replayGainAlbumPeak,
+      artistParticipants: artistParticipants ?? this.artistParticipants,
     );
   }
 }

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -7,7 +7,6 @@ import '../providers/providers.dart';
 import '../services/subsonic_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/widgets.dart';
-import 'artist_screen.dart';
 import '../l10n/app_localizations.dart';
 import '../services/offline_service.dart';
 
@@ -274,25 +273,13 @@ class _AlbumScreenState extends State<AlbumScreen> {
                         textAlign: TextAlign.center,
                       ),
                       const SizedBox(height: 4),
-                      GestureDetector(
-                        onTap: () {
-                          if (_album!.artistId != null) {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) =>
-                                    ArtistScreen(artistId: _album!.artistId!),
-                              ),
-                            );
-                          }
-                        },
-                        child: Text(
-                          _album!.artist ??
-                              AppLocalizations.of(context)!.unknownArtist,
-                          style: theme.textTheme.titleLarge?.copyWith(
-                            color: AppTheme.appleMusicRed,
-                          ),
-                          textAlign: TextAlign.center,
+                      MultiArtistWidget(
+                        artists: _album!.artistParticipants,
+                        artistFallback: _album!.artist ??
+                            AppLocalizations.of(context)!.unknownArtist,
+                        artistIdFallback: _album!.artistId,
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          color: AppTheme.appleMusicRed,
                         ),
                       ),
                       const SizedBox(height: 4),

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -241,7 +241,10 @@ class _LibraryScreenState extends State<LibraryScreen> {
             type: 'Album',
             id: a.id,
             name: a.name,
-            subtitle: a.artist ?? '',
+            subtitle: a.artistParticipants != null &&
+                    a.artistParticipants!.isNotEmpty
+                ? a.artistParticipants!.map((r) => r.name).join(', ')
+                : (a.artist ?? ''),
             coverArt: a.coverArt,
           ),
         ),

--- a/lib/screens/now_playing_screen.dart
+++ b/lib/screens/now_playing_screen.dart
@@ -23,6 +23,7 @@ import '../widgets/compact_lyrics_view.dart';
 import 'album_screen.dart';
 import 'artist_screen.dart';
 import '../widgets/cast_button.dart';
+import '../widgets/multi_artist_widget.dart';
 import '../widgets/album_artwork.dart' show isLocalFilePath;
 
 const _kCarouselGap = 40.0;
@@ -1649,237 +1650,9 @@ class _SongInfoState extends State<_SongInfo> {
     }
   }
 
-  void _navigateToArtist(BuildContext context) {
-    final artistName = widget.song?.artist;
-    final artistId = widget.song?.artistId;
-
-    if (artistName == null) return;
-
-    List<String> artists = [];
-
-    final slashParts = artistName.split('/');
-    for (final part in slashParts) {
-      final ampParts = part.split('&');
-      for (final ampPart in ampParts) {
-        String remaining = ampPart;
-        final featPatterns = [
-          ' feat. ',
-          ' feat ',
-          ' ft. ',
-          ' ft ',
-          ' featuring ',
-        ];
-        for (final pattern in featPatterns) {
-          if (remaining.toLowerCase().contains(pattern.toLowerCase())) {
-            final parts = remaining.split(
-              RegExp(pattern, caseSensitive: false),
-            );
-            artists.addAll(
-              parts.map((a) => a.trim()).where((a) => a.isNotEmpty),
-            );
-            remaining = '';
-            break;
-          }
-        }
-        if (remaining.isNotEmpty) {
-          artists.add(remaining.trim());
-        }
-      }
-    }
-
-    artists = artists.where((a) => a.isNotEmpty).toSet().toList();
-
-    if (artists.length > 1) {
-      _showArtistSelectionDialog(context, artists);
-    } else if (artistId != null) {
-      Navigator.pop(context);
-      NavigationHelper.push(context, ArtistScreen(artistId: artistId));
-    } else if (artists.isNotEmpty) {
-      _searchAndNavigateToArtist(context, artists.first);
-    }
-  }
-
-  Future<void> _searchAndNavigateToArtist(
-    BuildContext context,
-    String artistName,
-  ) async {
-    final subsonicService = Provider.of<SubsonicService>(
-      context,
-      listen: false,
-    );
-
-    try {
-      final result = await subsonicService.search(
-        artistName,
-        artistCount: 5,
-        albumCount: 0,
-        songCount: 0,
-      );
-
-      if (result.artists.isNotEmpty) {
-        final matchedArtist = result.artists.firstWhere(
-          (a) => a.name.toLowerCase() == artistName.toLowerCase(),
-          orElse: () => result.artists.first,
-        );
-
-        if (context.mounted) {
-          Navigator.pop(context);
-          NavigationHelper.push(
-            context,
-            ArtistScreen(artistId: matchedArtist.id),
-          );
-        }
-      } else {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                AppLocalizations.of(context)!.artistNotFound(artistName),
-              ),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-        }
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              AppLocalizations.of(context)!.errorSearchingArtist(e),
-            ),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
-    }
-  }
-
-  Future<void> _showArtistSelectionDialog(
-    BuildContext context,
-    List<String> artists,
-  ) async {
-    final subsonicService = Provider.of<SubsonicService>(
-      context,
-      listen: false,
-    );
-
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.transparent,
-      builder: (ctx) => Container(
-        decoration: BoxDecoration(
-          color: Theme.of(ctx).scaffoldBackgroundColor,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-        ),
-        child: SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const SizedBox(height: 12),
-              Container(
-                width: 40,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: Colors.grey[400],
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'Select Artist',
-                  style: Theme.of(
-                    ctx,
-                  ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
-              const SizedBox(height: 8),
-              ...artists.map(
-                (artistName) => ListTile(
-                  leading: const CircleAvatar(child: Icon(Icons.person)),
-                  title: Text(artistName),
-                  onTap: () async {
-                    Navigator.pop(ctx);
-
-                    try {
-                      final result = await subsonicService.search(
-                        artistName,
-                        artistCount: 5,
-                        albumCount: 0,
-                        songCount: 0,
-                      );
-
-                      if (result.artists.isNotEmpty) {
-                        final matchedArtist = result.artists.firstWhere(
-                          (a) =>
-                              a.name.toLowerCase() == artistName.toLowerCase(),
-                          orElse: () => result.artists.first,
-                        );
-
-                        if (context.mounted) {
-                          Navigator.pop(context);
-                          NavigationHelper.push(
-                            context,
-                            ArtistScreen(artistId: matchedArtist.id),
-                          );
-                        }
-                      } else {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(
-                                AppLocalizations.of(
-                                  context,
-                                )!.artistNotFound(artistName),
-                              ),
-                              duration: const Duration(seconds: 2),
-                            ),
-                          );
-                        }
-                      }
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              AppLocalizations.of(
-                                context,
-                              )!.errorSearchingArtist(e),
-                            ),
-                            duration: const Duration(seconds: 2),
-                          ),
-                        );
-                      }
-                    }
-                  },
-                ),
-              ),
-              const SizedBox(height: 16),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     if (widget.song == null) return const SizedBox.shrink();
-
-    final artistName = widget.song!.artist;
-    final hasMultipleArtists =
-        artistName != null &&
-        (artistName.contains('/') ||
-            artistName.contains('&') ||
-            artistName.toLowerCase().contains(' feat.') ||
-            artistName.toLowerCase().contains(' feat ') ||
-            artistName.toLowerCase().contains(' ft.') ||
-            artistName.toLowerCase().contains(' ft ') ||
-            artistName.toLowerCase().contains(' featuring '));
-    final isArtistClickable =
-        widget.song!.artistId != null || hasMultipleArtists;
 
     return Row(
       children: [
@@ -1898,26 +1671,17 @@ class _SongInfoState extends State<_SongInfo> {
                 overflow: TextOverflow.ellipsis,
               ),
               const SizedBox(height: 4),
-              GestureDetector(
-                onTap: isArtistClickable
-                    ? () => _navigateToArtist(context)
-                    : null,
-                child: Text(
-                  (widget.song!.artist ?? 'Unknown Artist').replaceAll(
-                    '/',
-                    ' / ',
-                  ),
-                  style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.7),
-                    fontSize: 18,
-                    decoration: isArtistClickable
-                        ? TextDecoration.underline
-                        : null,
-                    decorationColor: Colors.white.withValues(alpha: 0.4),
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+              MultiArtistWidget(
+                artists: widget.song!.artistParticipants,
+                artistFallback: widget.song!.artist,
+                artistIdFallback: widget.song!.artistId,
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.7),
+                  fontSize: 18,
                 ),
+                onBeforeNavigate: () {
+                  if (Navigator.canPop(context)) Navigator.pop(context);
+                },
               ),
             ],
           ),

--- a/lib/widgets/album_card.dart
+++ b/lib/widgets/album_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/album.dart';
 import '../theme/app_theme.dart';
 import 'album_artwork.dart';
+import 'multi_artist_widget.dart';
 
 class AlbumCard extends StatelessWidget {
   final Album album;
@@ -38,14 +39,14 @@ class AlbumCard extends StatelessWidget {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
-            if (album.artist != null)
-              Text(
-                album.artist!,
+            if (album.artist != null || album.artistParticipants != null)
+              MultiArtistWidget(
+                artists: album.artistParticipants,
+                artistFallback: album.artist,
+                artistIdFallback: album.artistId,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: AppTheme.lightSecondaryText,
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
               ),
           ],
         ),
@@ -117,14 +118,14 @@ class AlbumCardWide extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  if (album.artist != null)
-                    Text(
-                      album.artist!,
+                  if (album.artist != null || album.artistParticipants != null)
+                    MultiArtistWidget(
+                      artists: album.artistParticipants,
+                      artistFallback: album.artist,
+                      artistIdFallback: album.artistId,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: Colors.white70,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                     ),
                 ],
               ),

--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -45,7 +45,10 @@ class MiniPlayer extends StatelessWidget {
               null; 
         } else if (currentSong != null) {
           title = currentSong.title;
-          subtitle = currentSong.artist;
+          subtitle = currentSong.artistParticipants != null &&
+                  currentSong.artistParticipants!.isNotEmpty
+              ? currentSong.artistParticipants!.map((a) => a.name).join(', ')
+              : currentSong.artist;
           coverArt = currentSong.coverArt;
         } else {
           return const SizedBox.shrink();

--- a/lib/widgets/multi_artist_widget.dart
+++ b/lib/widgets/multi_artist_widget.dart
@@ -119,7 +119,7 @@ class MultiArtistWidget extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (ctx) => _ArtistsBottomSheet(
+      builder: (ctx) => ArtistsBottomSheet(
         artists: artistList,
         onArtistTap: (artist) {
           Navigator.pop(ctx);
@@ -202,11 +202,12 @@ class MultiArtistWidget extends StatelessWidget {
   }
 }
 
-class _ArtistsBottomSheet extends StatelessWidget {
+class ArtistsBottomSheet extends StatelessWidget {
   final List<ArtistRef> artists;
   final void Function(ArtistRef) onArtistTap;
 
-  const _ArtistsBottomSheet({
+  const ArtistsBottomSheet({
+    super.key,
     required this.artists,
     required this.onArtistTap,
   });

--- a/lib/widgets/multi_artist_widget.dart
+++ b/lib/widgets/multi_artist_widget.dart
@@ -83,15 +83,36 @@ class MultiArtistWidget extends StatelessWidget {
         albumCount: 0,
         songCount: 0,
       );
-      if (result.artists.isNotEmpty && context.mounted) {
+      if (!context.mounted) return;
+      if (result.artists.isNotEmpty) {
         final matched = result.artists.firstWhere(
           (a) => a.name.toLowerCase() == name.toLowerCase(),
           orElse: () => result.artists.first,
         );
         onBeforeNavigate?.call();
         NavigationHelper.push(context, ArtistScreen(artistId: matched.id));
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.artistNotFound(name),
+            ),
+            duration: const Duration(seconds: 2),
+          ),
+        );
       }
-    } catch (_) {}
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.errorSearchingArtist(e),
+            ),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    }
   }
 
   void _showArtistsSheet(BuildContext context, List<ArtistRef> artistList) {
@@ -114,7 +135,7 @@ class MultiArtistWidget extends StatelessWidget {
 
     if (effectiveArtists.isEmpty) {
       return Text(
-        'Unknown Artist',
+        AppLocalizations.of(context)!.unknownArtist,
         style: style,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
@@ -234,7 +255,7 @@ class _ArtistsBottomSheet extends StatelessWidget {
                   height: 46,
                   child: ClipOval(
                     child: AlbumArtwork(
-                      coverArt: artist.id.isNotEmpty ? artist.id : null,
+                      coverArt: artist.effectiveCoverArt,
                       size: 46,
                       borderRadius: 23,
                       shadow: const BoxShadow(color: Colors.transparent),

--- a/lib/widgets/multi_artist_widget.dart
+++ b/lib/widgets/multi_artist_widget.dart
@@ -1,0 +1,257 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/artist_ref.dart';
+import '../screens/artist_screen.dart';
+import '../services/subsonic_service.dart';
+import '../theme/app_theme.dart';
+import '../utils/navigation_helper.dart';
+import 'album_artwork.dart';
+
+/// Displays a list of artists as "Artist 1, Artist 2, …".
+///
+/// Behavior differs by platform:
+/// - **Desktop**: each artist name is an individually-clickable underlined link.
+/// - **Mobile / single artist**: tapping the whole row opens a bottom sheet
+///   (for multiple artists) or navigates directly (for a single artist).
+///
+/// Falls back gracefully when [artists] is null (non-Navidrome Subsonic servers):
+/// the [artistFallback] string is shown as a single clickable item that
+/// navigates via [artistIdFallback].
+class MultiArtistWidget extends StatelessWidget {
+  /// Parsed artist list from Navidrome's `participants` field. Optional.
+  final List<ArtistRef>? artists;
+
+  /// The raw artist string from the standard Subsonic `artist` field.
+  /// Used when [artists] is null.
+  final String? artistFallback;
+
+  /// The primary `artistId` from the Subsonic response, used as navigation
+  /// target when [artists] is null.
+  final String? artistIdFallback;
+
+  /// Text style applied to artist names.
+  final TextStyle? style;
+
+  /// Called synchronously just before navigating away (e.g. to pop a modal
+  /// screen before pushing the artist screen).
+  final VoidCallback? onBeforeNavigate;
+
+  const MultiArtistWidget({
+    super.key,
+    this.artists,
+    this.artistFallback,
+    this.artistIdFallback,
+    this.style,
+    this.onBeforeNavigate,
+  });
+
+  static bool get _isDesktop {
+    if (kIsWeb) return false;
+    return Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+  }
+
+  List<ArtistRef> _effectiveArtists() {
+    if (artists != null && artists!.isNotEmpty) return artists!;
+    final name = artistFallback;
+    final id = artistIdFallback;
+    if (name != null || id != null) {
+      return [ArtistRef(id: id ?? '', name: name ?? '')];
+    }
+    return [];
+  }
+
+  void _navigate(BuildContext context, ArtistRef artist) {
+    if (artist.id.isNotEmpty) {
+      onBeforeNavigate?.call();
+      NavigationHelper.push(context, ArtistScreen(artistId: artist.id));
+    } else if (artist.name.isNotEmpty) {
+      _searchAndNavigate(context, artist.name);
+    }
+  }
+
+  Future<void> _searchAndNavigate(BuildContext context, String name) async {
+    try {
+      final subsonic = Provider.of<SubsonicService>(context, listen: false);
+      final result = await subsonic.search(
+        name,
+        artistCount: 5,
+        albumCount: 0,
+        songCount: 0,
+      );
+      if (result.artists.isNotEmpty && context.mounted) {
+        final matched = result.artists.firstWhere(
+          (a) => a.name.toLowerCase() == name.toLowerCase(),
+          orElse: () => result.artists.first,
+        );
+        onBeforeNavigate?.call();
+        NavigationHelper.push(context, ArtistScreen(artistId: matched.id));
+      }
+    } catch (_) {}
+  }
+
+  void _showArtistsSheet(BuildContext context, List<ArtistRef> artistList) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => _ArtistsBottomSheet(
+        artists: artistList,
+        onArtistTap: (artist) {
+          Navigator.pop(ctx);
+          _navigate(context, artist);
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveArtists = _effectiveArtists();
+
+    if (effectiveArtists.isEmpty) {
+      return Text(
+        'Unknown Artist',
+        style: style,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    if (effectiveArtists.length == 1) {
+      final artist = effectiveArtists.first;
+      final clickable = artist.id.isNotEmpty || artist.name.isNotEmpty;
+      return MouseRegion(
+        cursor: clickable ? SystemMouseCursors.click : MouseCursor.defer,
+        child: GestureDetector(
+          onTap: clickable ? () => _navigate(context, artist) : null,
+          child: Text(
+            artist.name,
+            style: style,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      );
+    }
+
+    // Multiple artists
+    if (_isDesktop) {
+      return Wrap(
+        children: [
+          for (int i = 0; i < effectiveArtists.length; i++) ...[
+            MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => _navigate(context, effectiveArtists[i]),
+                child: Text(
+                  effectiveArtists[i].name,
+                  style: style?.copyWith(
+                    decoration: TextDecoration.underline,
+                    decorationColor: (style?.color ?? Colors.white)
+                        .withValues(alpha: 0.45),
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
+            if (i < effectiveArtists.length - 1) Text(', ', style: style),
+          ],
+        ],
+      );
+    }
+
+    // Mobile: whole line opens bottom sheet
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => _showArtistsSheet(context, effectiveArtists),
+        child: Text(
+          effectiveArtists.map((a) => a.name).join(', '),
+          style: style,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
+}
+
+class _ArtistsBottomSheet extends StatelessWidget {
+  final List<ArtistRef> artists;
+  final void Function(ArtistRef) onArtistTap;
+
+  const _ArtistsBottomSheet({
+    required this.artists,
+    required this.onArtistTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark ? AppTheme.darkSurface : Colors.white,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 12),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: isDark ? AppTheme.darkDivider : AppTheme.lightDivider,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Center(
+                child: Text(
+                  AppLocalizations.of(context)!.artists,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ...artists.map(
+              (artist) => ListTile(
+                leading: SizedBox(
+                  width: 46,
+                  height: 46,
+                  child: ClipOval(
+                    child: AlbumArtwork(
+                      coverArt: artist.id.isNotEmpty ? artist.id : null,
+                      size: 46,
+                      borderRadius: 23,
+                      shadow: const BoxShadow(color: Colors.transparent),
+                    ),
+                  ),
+                ),
+                title: Text(
+                  artist.name,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                onTap: () => onArtistTap(artist),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/multi_artist_widget.dart
+++ b/lib/widgets/multi_artist_widget.dart
@@ -9,7 +9,6 @@ import '../models/artist_ref.dart';
 import '../screens/artist_screen.dart';
 import '../services/subsonic_service.dart';
 import '../theme/app_theme.dart';
-import '../utils/navigation_helper.dart';
 import 'album_artwork.dart';
 
 /// Displays a list of artists as "Artist 1, Artist 2, …".
@@ -67,16 +66,20 @@ class MultiArtistWidget extends StatelessWidget {
 
   void _navigate(BuildContext context, ArtistRef artist) {
     if (artist.id.isNotEmpty) {
+      final navigator = Navigator.of(context);
       onBeforeNavigate?.call();
-      NavigationHelper.push(context, ArtistScreen(artistId: artist.id));
+      navigator.push(MaterialPageRoute(
+        builder: (_) => ArtistScreen(artistId: artist.id),
+      ));
     } else if (artist.name.isNotEmpty) {
       _searchAndNavigate(context, artist.name);
     }
   }
 
   Future<void> _searchAndNavigate(BuildContext context, String name) async {
+    final navigator = Navigator.of(context);
+    final subsonic = Provider.of<SubsonicService>(context, listen: false);
     try {
-      final subsonic = Provider.of<SubsonicService>(context, listen: false);
       final result = await subsonic.search(
         name,
         artistCount: 5,
@@ -90,7 +93,9 @@ class MultiArtistWidget extends StatelessWidget {
           orElse: () => result.artists.first,
         );
         onBeforeNavigate?.call();
-        NavigationHelper.push(context, ArtistScreen(artistId: matched.id));
+        navigator.push(MaterialPageRoute(
+          builder: (_) => ArtistScreen(artistId: matched.id),
+        ));
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -249,25 +254,35 @@ class ArtistsBottomSheet extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 8),
-            ...artists.map(
-              (artist) => ListTile(
-                leading: SizedBox(
-                  width: 46,
-                  height: 46,
-                  child: ClipOval(
-                    child: AlbumArtwork(
-                      coverArt: artist.effectiveCoverArt,
-                      size: 46,
-                      borderRadius: 23,
-                      shadow: const BoxShadow(color: Colors.transparent),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.45,
+              ),
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: artists.length,
+                itemBuilder: (_, i) {
+                  final artist = artists[i];
+                  return ListTile(
+                    leading: SizedBox(
+                      width: 46,
+                      height: 46,
+                      child: ClipOval(
+                        child: AlbumArtwork(
+                          coverArt: artist.effectiveCoverArt,
+                          size: 46,
+                          borderRadius: 23,
+                          shadow: const BoxShadow(color: Colors.transparent),
+                        ),
+                      ),
                     ),
-                  ),
-                ),
-                title: Text(
-                  artist.name,
-                  style: theme.textTheme.bodyLarge,
-                ),
-                onTap: () => onArtistTap(artist),
+                    title: Text(
+                      artist.name,
+                      style: theme.textTheme.bodyLarge,
+                    ),
+                    onTap: () => onArtistTap(artist),
+                  );
+                },
               ),
             ),
             const SizedBox(height: 12),

--- a/lib/widgets/song_tile.dart
+++ b/lib/widgets/song_tile.dart
@@ -410,15 +410,7 @@ class _SongOptionsSheetState extends State<_SongOptionsSheet> {
                       title: 'Go to Artist',
                       onTap: () {
                         Navigator.pop(context);
-                        if (widget.song.artistId != null) {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) =>
-                                  ArtistScreen(artistId: widget.song.artistId!),
-                            ),
-                          );
-                        }
+                        _navigateToArtist(context);
                       },
                     ),
                     _buildRatingTile(context),
@@ -727,6 +719,40 @@ class _SongOptionsSheetState extends State<_SongOptionsSheet> {
           ),
         );
       }
+    }
+  }
+
+  void _navigateToArtist(BuildContext context) {
+    final participants = widget.song.artistParticipants;
+
+    if (participants != null && participants.length > 1) {
+      showModalBottomSheet(
+        context: context,
+        backgroundColor: Colors.transparent,
+        builder: (ctx) => ArtistsBottomSheet(
+          artists: participants,
+          onArtistTap: (artist) {
+            Navigator.pop(ctx);
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => ArtistScreen(artistId: artist.id),
+              ),
+            );
+          },
+        ),
+      );
+      return;
+    }
+
+    final artistId = participants?.firstOrNull?.id ?? widget.song.artistId;
+    if (artistId != null && artistId.isNotEmpty) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ArtistScreen(artistId: artistId),
+        ),
+      );
     }
   }
 

--- a/lib/widgets/song_tile.dart
+++ b/lib/widgets/song_tile.dart
@@ -137,6 +137,32 @@ class SongTile extends StatelessWidget {
 
   Widget _buildSubtitleWidget(ThemeData theme) {
     if (showArtist) {
+      if (showAlbum && song.album != null) {
+        return Row(
+          children: [
+            Flexible(
+              flex: 3,
+              fit: FlexFit.loose,
+              child: MultiArtistWidget(
+                artists: song.artistParticipants,
+                artistFallback: song.artist,
+                artistIdFallback: song.artistId,
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+            Flexible(
+              flex: 1,
+              fit: FlexFit.loose,
+              child: Text(
+                ' \u2022 ${song.album}',
+                style: theme.textTheme.bodySmall,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        );
+      }
       return MultiArtistWidget(
         artists: song.artistParticipants,
         artistFallback: song.artist,

--- a/lib/widgets/song_tile.dart
+++ b/lib/widgets/song_tile.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import '../l10n/app_localizations.dart';
+import '../models/artist_ref.dart';
 import '../models/song.dart';
+import '../utils/navigation_helper.dart';
 import '../providers/player_provider.dart';
 import '../providers/library_provider.dart';
 import '../services/jukebox_service.dart';
@@ -409,8 +411,9 @@ class _SongOptionsSheetState extends State<_SongOptionsSheet> {
                       icon: Icons.person_rounded,
                       title: 'Go to Artist',
                       onTap: () {
-                        Navigator.pop(context);
-                        _navigateToArtist(context);
+                        final nav = Navigator.of(context);
+                        nav.pop();
+                        _navigateToArtist(nav);
                       },
                     ),
                     _buildRatingTile(context),
@@ -722,37 +725,45 @@ class _SongOptionsSheetState extends State<_SongOptionsSheet> {
     }
   }
 
-  void _navigateToArtist(BuildContext context) {
+  void _navigateToArtist(NavigatorState nav) {
     final participants = widget.song.artistParticipants;
 
     if (participants != null && participants.length > 1) {
+      final ctx = NavigationHelper.navigatorKey.currentContext;
+      if (ctx == null) return;
       showModalBottomSheet(
-        context: context,
+        context: ctx,
         backgroundColor: Colors.transparent,
-        builder: (ctx) => ArtistsBottomSheet(
+        builder: (sheetCtx) => ArtistsBottomSheet(
           artists: participants,
           onArtistTap: (artist) {
-            Navigator.pop(ctx);
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => ArtistScreen(artistId: artist.id),
-              ),
-            );
+            Navigator.pop(sheetCtx);
+            _pushArtist(nav, artist);
           },
         ),
       );
       return;
     }
 
-    final artistId = participants?.firstOrNull?.id ?? widget.song.artistId;
+    final single = participants?.firstOrNull;
+    if (single != null) {
+      _pushArtist(nav, single);
+      return;
+    }
+
+    final artistId = widget.song.artistId;
     if (artistId != null && artistId.isNotEmpty) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => ArtistScreen(artistId: artistId),
-        ),
-      );
+      nav.push(MaterialPageRoute(
+        builder: (_) => ArtistScreen(artistId: artistId),
+      ));
+    }
+  }
+
+  void _pushArtist(NavigatorState nav, ArtistRef artist) {
+    if (artist.id.isNotEmpty) {
+      nav.push(MaterialPageRoute(
+        builder: (_) => ArtistScreen(artistId: artist.id),
+      ));
     }
   }
 

--- a/lib/widgets/song_tile.dart
+++ b/lib/widgets/song_tile.dart
@@ -13,6 +13,7 @@ import '../providers/auth_provider.dart';
 import '../theme/app_theme.dart';
 import 'album_artwork.dart';
 import 'animated_equalizer.dart';
+import 'multi_artist_widget.dart';
 import '../screens/album_screen.dart';
 import '../screens/artist_screen.dart';
 
@@ -67,12 +68,7 @@ class SongTile extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
           subtitle: showArtist || showAlbum
-              ? Text(
-                  _buildSubtitle(),
-                  style: theme.textTheme.bodySmall,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                )
+              ? _buildSubtitleWidget(theme)
               : null,
           trailing: _buildTrailing(context),
           onTap: onTap ?? () => _playSong(context),
@@ -139,15 +135,22 @@ class SongTile extends StatelessWidget {
     return null;
   }
 
-  String _buildSubtitle() {
-    final parts = <String>[];
-    if (showArtist && song.artist != null) {
-      parts.add(song.artist!);
+  Widget _buildSubtitleWidget(ThemeData theme) {
+    if (showArtist) {
+      return MultiArtistWidget(
+        artists: song.artistParticipants,
+        artistFallback: song.artist,
+        artistIdFallback: song.artistId,
+        style: theme.textTheme.bodySmall,
+      );
     }
-    if (showAlbum && song.album != null) {
-      parts.add(song.album!);
-    }
-    return parts.join(' • ');
+
+    return Text(
+      song.album ?? '',
+      style: theme.textTheme.bodySmall,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
   }
 
   Widget _buildTrailing(BuildContext context) {

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -4,6 +4,7 @@ export 'artist_card.dart';
 export 'song_tile.dart';
 export 'animated_equalizer.dart';
 export 'mini_player.dart';
+export 'multi_artist_widget.dart';
 export 'section_header.dart';
 export 'shimmer_loading.dart';
 export 'desktop_player_bar.dart';


### PR DESCRIPTION
## Summary

Adds proper multi-artist rendering across the app using Navidrome's extended artists fields. Falls back gracefully to the standard Subsonic artist string on servers that don't expose these fields, so nothing breaks for non-Navidrome setups.

## Changes
### Models
- ArtistRef - new lightweight model that parses entries from Navidrome's artists
- Song - added optional artistParticipants parsed from json
- Album — added optional artistParticipants parsed from json

### MultiArtistWidget
Reusable widget that renders a list of artists as "Artist 1, Artist 2, …" with platform-aware interaction
- Desktop — each artist name is an individually clickable underlined link that navigates directly to the artist screen
- Mobile (single artist) — tapping navigates directly
- Mobile (multiple artists) — tapping the line opens a bottom sheet titled "Artists" with a scrollable list; each row shows the artist's real cover image and name; tapping navigates to that artist; sheet is dismissed by tapping the backdrop or swiping down
- Fallback — when artistParticipants is null (non-Navidrome), shows the raw artist string and navigates via artistId, identical to the previous behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-artist support: albums and songs can display multiple participating artists across library, album, song list, mini player, now playing, and album cards.
  * New unified artist UI: a MultiArtist component with platform-specific interactions, per-artist navigation, chooser sheet, and fallback labels.
  * Improved artist navigation: attempts name-based resolution when an ID is unavailable and shows localized error feedback on failures.

* **Chores**
  * Added a compact artist reference model and re-export for broader use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->