### PR TITLE
feat: add tap cover to show lyrics

### DIFF
--- a/lib/screens/now_playing_screen.dart
+++ b/lib/screens/now_playing_screen.dart
@@ -311,14 +311,21 @@ class _NowPlayingScreenState extends State<NowPlayingScreen>
                   1.0,
                 ),
               transformAlignment: Alignment.center,
-              child: _SwipeableAlbumArtwork(
-                currentImageUrl: _cachedImageUrl ?? '',
-                currentThumbnailUrl: _cachedThumbnailUrl,
-                previewImageUrl: _getPreviewArtworkUrl(_previewSong),
-                hasPreviewSong: _previewSong != null,
-                size: artworkSize,
-                swipeProgress: _swipeProgress,
-                horizontalDragOffset: _horizontalDragOffset,
+              child: GestureDetector(
+                onTap: () {
+                  setState(() {
+                    _showLyrics = true;
+                  });
+                },
+                child: _SwipeableAlbumArtwork(
+                  currentImageUrl: _cachedImageUrl ?? '',
+                  currentThumbnailUrl: _cachedThumbnailUrl,
+                  previewImageUrl: _getPreviewArtworkUrl(_previewSong),
+                  hasPreviewSong: _previewSong != null,
+                  size: artworkSize,
+                  swipeProgress: _swipeProgress,
+                  horizontalDragOffset: _horizontalDragOffset,
+                ),
               ),
             ),
           ),
@@ -594,21 +601,28 @@ class _NowPlayingScreenState extends State<NowPlayingScreen>
                                               1.0,
                                             ),
                                           transformAlignment: Alignment.center,
-                                          child: _SwipeableAlbumArtwork(
-                                            currentImageUrl:
-                                                _cachedImageUrl ?? '',
-                                            currentThumbnailUrl:
-                                                _cachedThumbnailUrl,
-                                            previewImageUrl:
-                                                _getPreviewArtworkUrl(
-                                                  _previewSong,
-                                                ),
-                                            hasPreviewSong:
-                                                _previewSong != null,
-                                            size: artworkSize,
-                                            swipeProgress: _swipeProgress,
-                                            horizontalDragOffset:
-                                                _horizontalDragOffset,
+                                          child: GestureDetector(
+                                            onTap: () {
+                                              setState(() {
+                                                _showLyrics = true;
+                                              });
+                                            },
+                                            child: _SwipeableAlbumArtwork(
+                                              currentImageUrl:
+                                                  _cachedImageUrl ?? '',
+                                              currentThumbnailUrl:
+                                                  _cachedThumbnailUrl,
+                                              previewImageUrl:
+                                                  _getPreviewArtworkUrl(
+                                                    _previewSong,
+                                                  ),
+                                              hasPreviewSong:
+                                                  _previewSong != null,
+                                              size: artworkSize,
+                                              swipeProgress: _swipeProgress,
+                                              horizontalDragOffset:
+                                                  _horizontalDragOffset,
+                                            ),
                                           ),
                                         ),
 


### PR DESCRIPTION
Add a feature to show lyrics when tapping the cover.

Tested locally and works fine. No impact on existing features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping album artwork on the Now Playing screen now displays song lyrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->