### PR TITLE
fix: incorrect sorting in recently added list

### DIFF
--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -25,6 +25,7 @@ class Song {
   final double? replayGainTrackPeak;
   final double? replayGainAlbumPeak;
   final List<ArtistRef>? artistParticipants;
+  final DateTime? created;
 
   Song({
     required this.id,
@@ -51,6 +52,7 @@ class Song {
     this.replayGainTrackPeak,
     this.replayGainAlbumPeak,
     this.artistParticipants,
+    this.created,
   });
 
   factory Song.fromJson(Map<String, dynamic> json) {
@@ -81,6 +83,9 @@ class Song {
       replayGainTrackPeak: (replayGain?['trackPeak'] as num?)?.toDouble(),
       replayGainAlbumPeak: (replayGain?['albumPeak'] as num?)?.toDouble(),
       artistParticipants: ArtistRef.parseList(json['artists']),
+      created: json['created'] != null
+          ? DateTime.tryParse(json['created'].toString())
+          : null,
     );
   }
 
@@ -111,6 +116,7 @@ class Song {
       },
       if (artistParticipants != null)
         'artists': artistParticipants!.map((a) => a.toJson()).toList(),
+      'created': created?.toIso8601String(),
     };
   }
 
@@ -146,6 +152,7 @@ class Song {
     double? replayGainTrackPeak,
     double? replayGainAlbumPeak,
     List<ArtistRef>? artistParticipants,
+    DateTime? created,
   }) {
     return Song(
       id: id ?? this.id,
@@ -172,6 +179,7 @@ class Song {
       replayGainTrackPeak: replayGainTrackPeak ?? this.replayGainTrackPeak,
       replayGainAlbumPeak: replayGainAlbumPeak ?? this.replayGainAlbumPeak,
       artistParticipants: artistParticipants ?? this.artistParticipants,
+      created: created ?? this.created,
     );
   }
 }

--- a/lib/providers/library_provider.dart
+++ b/lib/providers/library_provider.dart
@@ -300,8 +300,10 @@ class LibraryProvider extends ChangeNotifier {
         offset += pageSize;
       }
 
-      _cachedAllAlbums = allAlbums;
+      final previousAlbums = _cachedAllAlbums;
+      final previousSongs = _cachedAllSongs;
       final Map<String, Song> songById = {};
+      var failedAlbumLoads = 0;
       for (final album in allAlbums) {
         try {
           final albumSongs = await _subsonicService.getAlbumSongs(album.id);
@@ -309,10 +311,22 @@ class LibraryProvider extends ChangeNotifier {
             songById[song.id] = song;
           }
         } catch (e) {
+          failedAlbumLoads++;
           debugPrint('Error loading album ${album.id}: $e');
         }
       }
 
+      if (failedAlbumLoads > 0) {
+        _cachedAllAlbums = previousAlbums;
+        _cachedAllSongs = previousSongs;
+        debugPrint(
+          'Background refresh incomplete: $failedAlbumLoads album(s) failed; keeping previous cache.',
+        );
+        notifyListeners();
+        return;
+      }
+
+      _cachedAllAlbums = allAlbums;
       _cachedAllSongs = songById.values.toList();
       _lastCacheUpdate = DateTime.now();
 

--- a/lib/providers/library_provider.dart
+++ b/lib/providers/library_provider.dart
@@ -301,7 +301,19 @@ class LibraryProvider extends ChangeNotifier {
       }
 
       _cachedAllAlbums = allAlbums;
-      _cachedAllSongs = [];
+      final Map<String, Song> songById = {};
+      for (final album in allAlbums) {
+        try {
+          final albumSongs = await _subsonicService.getAlbumSongs(album.id);
+          for (final song in albumSongs) {
+            songById[song.id] = song;
+          }
+        } catch (e) {
+          debugPrint('Error loading album ${album.id}: $e');
+        }
+      }
+
+      _cachedAllSongs = songById.values.toList();
       _lastCacheUpdate = DateTime.now();
 
       await _saveCachedData();

--- a/lib/screens/all_songs_screen.dart
+++ b/lib/screens/all_songs_screen.dart
@@ -105,8 +105,14 @@ class _AllSongsScreenState extends State<AllSongsScreen> {
         );
         break;
       case SongSortOption.recentlyAdded:
-        
-        _sortedSongs = List.from(_songs.reversed);
+        _sortedSongs.sort((a, b) {
+          final aCreated = a.created;
+          final bCreated = b.created;
+          if (aCreated == null && bCreated == null) return 0;
+          if (aCreated == null) return 1;
+          if (bCreated == null) return -1;
+          return bCreated.compareTo(aCreated);
+        });
         break;
     }
   }

--- a/test/models/song_test.dart
+++ b/test/models/song_test.dart
@@ -33,6 +33,22 @@ void main() {
       expect(song.album, isNull);
       expect(song.artist, isNull);
       expect(song.duration, isNull);
+      expect(song.created, isNull);
+    });
+
+    test('should parse created field from JSON', () {
+      final json = {
+        'id': '123',
+        'title': 'Test Song',
+        'created': '2026-03-18T13:37:27.257653751Z',
+      };
+
+      final song = Song.fromJson(json);
+
+      expect(song.created, isNotNull);
+      expect(song.created!.year, 2026);
+      expect(song.created!.month, 3);
+      expect(song.created!.day, 18);
     });
 
     test('should convert Song to JSON', () {


### PR DESCRIPTION
This PR fixes an issue with the sorting of the "recently added" list.

Changes
Corrected the sorting logic for recently added items
Ensured items are ordered properly by time
Improved accuracy and user experience when browsing recent additions
Background

Previously, the list could be incorrectly ordered in certain cases, causing newly added items to not appear in the expected position.

Also, a small request:
In a previous PR, the squash merge caused the contribution attribution to be lost.
If possible, could you please preserve the original commit authorship (e.g., using merge or rebase),
or include Co-authored-by when squashing, so the contribution can be properly credited?

Thanks a lot!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Songs now include creation date information for tracking when items were added to your library.

* **Improvements**
  * "Recently Added" sorting now uses actual creation timestamps for more accurate ordering; items without a creation date are treated as older.
  * Library refresh process improved with safer error handling: partial failures during album loading preserve previous cache and avoid corrupt updates.

* **Tests**
  * Added/updated tests to cover parsing and absence of song creation dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->