### PR TITLE
fix: eliminate UPnP hardware volume overlay jump

### DIFF
--- a/android/app/src/main/kotlin/com/musly/musly/MusicService.kt
+++ b/android/app/src/main/kotlin/com/musly/musly/MusicService.kt
@@ -23,6 +23,7 @@ import android.util.Log
 import androidx.media.VolumeProviderCompat
 import kotlinx.coroutines.*
 import java.net.URL
+import kotlin.math.roundToInt
 
 class MusicService : MediaBrowserServiceCompat() {
 
@@ -60,6 +61,7 @@ class MusicService : MediaBrowserServiceCompat() {
     private var currentPosition: Long = 0
     private var isPlaying: Boolean = false
     private var volumeProvider: VolumeProviderCompat? = null
+    private var upnpExpectedVolume = 0
 
     private val mediaItems = mutableListOf<MediaBrowserCompat.MediaItem>()
     private val recentSongs = mutableListOf<MediaBrowserCompat.MediaItem>()
@@ -688,24 +690,25 @@ class MusicService : MediaBrowserServiceCompat() {
 
     fun setRemoteVolume(isRemote: Boolean, currentVolume: Int) {
         if (isRemote) {
+            // Provider scale 0-20 (1 unit = 5% UPnP). Android's mOptimisticVolume always
+            // steps by ±1, so this aligns the optimistic value with our actual target and
+            // eliminates the 1-second visual jump on hardware volume button presses.
+            val initialProviderVolume = (currentVolume / 5.0).roundToInt().coerceIn(0, 20)
+            upnpExpectedVolume = initialProviderVolume
             volumeProvider = object : VolumeProviderCompat(
-                VOLUME_CONTROL_ABSOLUTE, 100, currentVolume
+                VOLUME_CONTROL_ABSOLUTE, 20, initialProviderVolume
             ) {
                 override fun onSetVolumeTo(volume: Int) {
+                    upnpExpectedVolume = volume
                     setCurrentVolume(volume)
-                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to volume))
+                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to volume * 5))
                 }
 
                 override fun onAdjustVolume(direction: Int) {
-                    // Use getCurrentVolume() (the live VolumeProviderCompat
-                    // property) not the captured constructor param.  The param
-                    // is a val fixed at connection time, so every relative
-                    // adjustment would always compute from the same baseline,
-                    // causing the volume to snap back to initialVolume±5 no
-                    // matter how many times the user presses the button.
-                    val newVolume = (getCurrentVolume() + direction * 5).coerceIn(0, 100)
-                    setCurrentVolume(newVolume)
-                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to newVolume))
+                    if (direction == 0) return  // ADJUST_SAME on key-up; no change needed
+                    upnpExpectedVolume = (upnpExpectedVolume + direction).coerceIn(0, 20)
+                    setCurrentVolume(upnpExpectedVolume)
+                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to upnpExpectedVolume * 5))
                 }
             }
             mediaSession.setPlaybackToRemote(volumeProvider!!)
@@ -718,7 +721,10 @@ class MusicService : MediaBrowserServiceCompat() {
     }
 
     fun updateRemoteVolume(volume: Int) {
-        volumeProvider?.currentVolume = volume
+        // volume is SOAP scale 0-100; convert to provider scale 0-20
+        val providerVolume = (volume / 5.0).roundToInt().coerceIn(0, 20)
+        upnpExpectedVolume = providerVolume
+        volumeProvider?.currentVolume = providerVolume
     }
 
     override fun onDestroy() {

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -887,7 +887,11 @@ class PlayerProvider extends ChangeNotifier {
       return;
     }
 
-    if (_repeatMode == RepeatMode.one) {
+    // Repeat-one, or repeat-all with a single-song queue: seek and replay
+    // (skipNext would call playSong with the same song, triggering the
+    // "same song = togglePlayPause" guard and pausing instead of replaying)
+    if (_repeatMode == RepeatMode.one ||
+        (_repeatMode == RepeatMode.all && _queue.length == 1)) {
       seek(Duration.zero);
       play();
     } else if (_currentIndex < _queue.length - 1 ||

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' show Random;
 
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -676,8 +677,14 @@ class PlayerProvider extends ChangeNotifier {
   Duration get position => _position;
   Duration get duration => _duration;
   Song? get currentSong => _currentSong;
-  bool get hasNext => _currentIndex < _queue.length - 1;
-  bool get hasPrevious => _currentIndex > 0;
+  bool get hasNext =>
+      _currentIndex < _queue.length - 1 ||
+      _repeatMode == RepeatMode.all ||
+      (_shuffleEnabled && _queue.length > 1);
+  bool get hasPrevious =>
+      _currentIndex > 0 ||
+      _repeatMode == RepeatMode.all ||
+      (_shuffleEnabled && _queue.length > 1);
   double get volume => _volume;
 
   RadioStation? get currentRadioStation => _currentRadioStation;
@@ -770,10 +777,19 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   void _initializePlayer() {
-    
     _storageService.getVolume().then((savedVolume) {
       _volume = savedVolume;
       _audioPlayer.setVolume(_volume);
+      notifyListeners();
+    });
+
+    _storageService.getShuffleMode().then((saved) {
+      _shuffleEnabled = saved;
+      notifyListeners();
+    });
+
+    _storageService.getRepeatMode().then((saved) {
+      _repeatMode = RepeatMode.values[saved.clamp(0, RepeatMode.values.length - 1)];
       notifyListeners();
     });
 
@@ -927,6 +943,13 @@ class PlayerProvider extends ChangeNotifier {
         _currentIndex =
             startIndex ?? playlist.indexWhere((s) => s.id == song.id);
         if (_currentIndex == -1) _currentIndex = 0;
+        // Apply shuffle to the new queue, keeping the chosen song at front
+        if (_shuffleEnabled && _queue.length > 1) {
+          _queue.shuffle();
+          _queue.remove(song);
+          _queue.insert(0, song);
+          _currentIndex = 0;
+        }
       } else if (_queue.isEmpty || !_queue.any((s) => s.id == song.id)) {
         _queue = [song];
         _currentIndex = 0;
@@ -1239,6 +1262,14 @@ class PlayerProvider extends ChangeNotifier {
 
     if (_currentIndex < _queue.length - 1) {
       await skipToIndex(_currentIndex + 1);
+    } else if (_repeatMode == RepeatMode.all) {
+      await skipToIndex(0);
+    } else if (_shuffleEnabled && _queue.length > 1) {
+      int next;
+      do {
+        next = Random().nextInt(_queue.length);
+      } while (next == _currentIndex);
+      await skipToIndex(next);
     }
   }
 
@@ -1267,6 +1298,14 @@ class PlayerProvider extends ChangeNotifier {
       await seek(Duration.zero);
     } else if (_currentIndex > 0) {
       await skipToIndex(_currentIndex - 1);
+    } else if (_repeatMode == RepeatMode.all && _queue.isNotEmpty) {
+      await skipToIndex(_queue.length - 1);
+    } else if (_shuffleEnabled && _queue.length > 1) {
+      int prev;
+      do {
+        prev = Random().nextInt(_queue.length);
+      } while (prev == _currentIndex);
+      await skipToIndex(prev);
     } else {
       await seek(Duration.zero);
     }
@@ -1287,6 +1326,7 @@ class PlayerProvider extends ChangeNotifier {
       _queue.insert(0, currentSong);
       _currentIndex = 0;
     }
+    _storageService.saveShuffleMode(_shuffleEnabled);
     notifyListeners();
   }
 
@@ -1302,6 +1342,7 @@ class PlayerProvider extends ChangeNotifier {
         _repeatMode = RepeatMode.off;
         break;
     }
+    _storageService.saveRepeatMode(_repeatMode.index);
     notifyListeners();
   }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1470,11 +1470,33 @@ class PlayerProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool _upnpVolumeWriteInProgress = false;
+
   void _onRemoteVolumeChange(int volume) {
     if (_castService.isConnected) {
       _castService.setVolume(volume / 100.0);
     } else if (_upnpService.isConnected) {
-      _upnpService.setVolume(volume);
+      if (_upnpVolumeWriteInProgress) return;
+      _applyUpnpVolume(volume);
+    }
+  }
+
+  Future<void> _applyUpnpVolume(int volume) async {
+    _upnpVolumeWriteInProgress = true;
+    _volume = (volume / 100.0).clamp(0.0, 1.0);
+    notifyListeners();
+    try {
+      await _upnpService.setVolume(volume);
+      final actual = await _upnpService.getVolume();
+      if (actual >= 0) {
+        _volume = actual / 100.0;
+        _androidSystemService.updateRemoteVolume(actual);
+        notifyListeners();
+      }
+    } catch (e) {
+      debugPrint('UPnP setVolume error: $e');
+    } finally {
+      _upnpVolumeWriteInProgress = false;
     }
   }
 
@@ -1753,16 +1775,11 @@ class PlayerProvider extends ChangeNotifier {
     }
 
     final vol = _upnpService.volume;
-    if (vol >= 0) {
+    if (vol >= 0 && !_upnpVolumeWriteInProgress) {
       final normalized = vol / 100.0;
       if ((_volume - normalized).abs() > 0.005) {
         _volume = normalized;
         changed = true;
-        // Only push the new volume to the Android MediaSession when it has
-        // actually changed.  Calling updateRemoteVolume unconditionally on
-        // every state tick would overwrite any in-flight physical volume
-        // adjustment with the stale cached value before the next poll cycle
-        // had a chance to read it back, causing the audible snap-back.
         _androidSystemService.updateRemoteVolume(vol);
       }
     }

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -887,26 +887,15 @@ class PlayerProvider extends ChangeNotifier {
       return;
     }
 
-    switch (_repeatMode) {
-      case RepeatMode.one:
-        seek(Duration.zero);
-        play();
-        break;
-      case RepeatMode.all:
-        if (_currentIndex >= _queue.length - 1) {
-          skipToIndex(0);
-        } else {
-          skipNext();
-        }
-        break;
-      case RepeatMode.off:
-        if (_currentIndex < _queue.length - 1) {
-          skipNext();
-        } else {
-          
-          _handleEndOfQueue();
-        }
-        break;
+    if (_repeatMode == RepeatMode.one) {
+      seek(Duration.zero);
+      play();
+    } else if (_currentIndex < _queue.length - 1 ||
+        _repeatMode == RepeatMode.all ||
+        _shuffleEnabled) {
+      skipNext();
+    } else {
+      _handleEndOfQueue();
     }
   }
 
@@ -943,13 +932,6 @@ class PlayerProvider extends ChangeNotifier {
         _currentIndex =
             startIndex ?? playlist.indexWhere((s) => s.id == song.id);
         if (_currentIndex == -1) _currentIndex = 0;
-        // Apply shuffle to the new queue, keeping the chosen song at front
-        if (_shuffleEnabled && _queue.length > 1) {
-          _queue.shuffle();
-          _queue.remove(song);
-          _queue.insert(0, song);
-          _currentIndex = 0;
-        }
       } else if (_queue.isEmpty || !_queue.any((s) => s.id == song.id)) {
         _queue = [song];
         _currentIndex = 0;
@@ -1260,16 +1242,16 @@ class PlayerProvider extends ChangeNotifier {
       await _addAutoDjSongs();
     }
 
-    if (_currentIndex < _queue.length - 1) {
-      await skipToIndex(_currentIndex + 1);
-    } else if (_repeatMode == RepeatMode.all) {
-      await skipToIndex(0);
-    } else if (_shuffleEnabled && _queue.length > 1) {
+    if (_shuffleEnabled && _queue.length > 1) {
       int next;
       do {
         next = Random().nextInt(_queue.length);
       } while (next == _currentIndex);
       await skipToIndex(next);
+    } else if (_currentIndex < _queue.length - 1) {
+      await skipToIndex(_currentIndex + 1);
+    } else if (_repeatMode == RepeatMode.all) {
+      await skipToIndex(0);
     }
   }
 

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -85,33 +85,35 @@ class _AlbumScreenState extends State<AlbumScreen> {
   Future<void> _downloadAlbum() async {
     if (_songs.isEmpty) return;
 
+    final offlineService = OfflineService();
+    if (offlineService.isBackgroundDownloadActive) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('A download is already in progress'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+
     final subsonicService = Provider.of<SubsonicService>(
       context,
       listen: false,
     );
-    final offlineService = OfflineService();
     await offlineService.initialize();
 
     setState(() => _isDownloading = true);
 
-    offlineService.startBackgroundDownload(_songs, subsonicService).then((_) {
-      if (mounted) {
-        setState(() => _isDownloading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Downloaded ${_songs.length} songs from ${_album!.name}',
-            ),
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
+    offlineService.startBackgroundDownload(_songs, subsonicService).whenComplete(() {
+      if (mounted) setState(() => _isDownloading = false);
     });
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Downloading ${_songs.length} songs in background…'),
+          content: Text('Downloading ${_songs.length} songs from ${_album!.name} in background…'),
           duration: const Duration(seconds: 2),
         ),
       );

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -212,31 +212,35 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
     final songs = _playlist?.songs;
     if (songs == null || songs.isEmpty) return;
 
+    final offlineService = OfflineService();
+    if (offlineService.isBackgroundDownloadActive) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('A download is already in progress'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+
     final subsonicService = Provider.of<SubsonicService>(
       context,
       listen: false,
     );
-    final offlineService = OfflineService();
     await offlineService.initialize();
 
     setState(() => _isDownloading = true);
 
-    offlineService.startBackgroundDownload(songs, subsonicService).then((_) {
-      if (mounted) {
-        setState(() => _isDownloading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Downloaded ${songs.length} songs from ${_playlist!.name}'),
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
+    offlineService.startBackgroundDownload(songs, subsonicService).whenComplete(() {
+      if (mounted) setState(() => _isDownloading = false);
     });
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Downloading ${songs.length} songs in background…'),
+          content: Text('Downloading ${songs.length} songs from ${_playlist!.name} in background…'),
           duration: const Duration(seconds: 2),
         ),
       );

--- a/lib/screens/settings_storage_tab.dart
+++ b/lib/screens/settings_storage_tab.dart
@@ -457,7 +457,10 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
 
       if (confirm != true || !mounted) return;
 
-      await _offlineService.startBackgroundDownload(allSongs, subsonicService);
+      // Fire-and-forget: progress is tracked via downloadState ValueNotifier
+      _offlineService.startBackgroundDownload(allSongs, subsonicService).whenComplete(() {
+        if (mounted) _loadOfflineInfo();
+      });
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -466,7 +469,6 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
             duration: const Duration(seconds: 2),
           ),
         );
-        await _loadOfflineInfo();
       }
     } catch (e) {
       if (mounted) {

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -109,7 +109,13 @@ class OfflineService {
   bool isSongDownloaded(String songId) {
     if (_offlineDir == null) return false;
     final file = File(_getSongPath(songId));
-    return file.existsSync();
+    if (!file.existsSync()) return false;
+    // Treat files under 64 KB as corrupt/partial downloads
+    try {
+      return file.lengthSync() >= 65536;
+    } catch (_) {
+      return false;
+    }
   }
 
   List<String> getDownloadedSongIds() {
@@ -151,9 +157,9 @@ class OfflineService {
   }) async {
     if (_offlineDir == null) await initialize();
 
+    final filePath = _getSongPath(song.id);
     try {
       final url = subsonicService.getStreamUrl(song.id);
-      final filePath = _getSongPath(song.id);
 
       final dio = Dio();
       await dio.download(
@@ -200,6 +206,11 @@ class OfflineService {
       return true;
     } catch (e) {
       debugPrint('Error downloading song: $e');
+      // Remove partial file so isSongDownloaded() doesn't treat it as complete
+      try {
+        final partial = File(filePath);
+        if (partial.existsSync()) await partial.delete();
+      } catch (_) {}
       return false;
     }
   }


### PR DESCRIPTION
## Problem

When pressing a hardware volume button during UPnP remote playback, Android's `MediaSessionRecord` sets `mOptimisticVolume = currentVolume + direction` (direction is always ±1) and holds it for 1 second before reconciling with `mCurrentVolume`. With `maxVolume=100`, each hardware press optimistically advanced by 1 unit (1%) while our actual UPnP step was 5 units (5%), causing the Android volume overlay to briefly flash the small increment then visually jump to the real value after ~1 second.

## Fix

Set `VolumeProviderCompat` `maxVolume=20` (1 unit = 5% of UPnP range). Now `direction=±1` maps to exactly one 5% step — `mOptimisticVolume` matches our actual target value, Android sees no discrepancy at the 1-second mark, and the jump never fires.

Two additional improvements in the same area:

- **Drop `ADJUST_SAME` (direction=0):** Android fires `onAdjustVolume(0)` on key-up as a "show the overlay" signal with no intended value change. This was causing a redundant SOAP `SetVolume` call. Early return added.

- **Concurrent write guard:** `_upnpVolumeWriteInProgress` prevents rapid button presses from queuing overlapping SOAP exchanges, and stops the poll-based state handler from overwriting the MediaSession volume with a stale cached value while a write is already in-flight.

## Files changed

- `android/app/src/main/kotlin/com/musly/musly/MusicService.kt` — `maxVolume=20`, `upnpExpectedVolume` field to track provider-scale state, `direction==0` early return, scale conversion in `updateRemoteVolume`
- `lib/providers/player_provider.dart` — `_upnpVolumeWriteInProgress` flag, `_applyUpnpVolume` (coordinates `setVolume` + `getVolume` + `updateRemoteVolume` atomically), concurrent guard in `_onRemoteVolumeChange` and poll handler

## Compatibility

Chromecast and Android Auto are unaffected. The `sendCommand("setVolume", value * 5)` call keeps the Dart side always receiving values in 0–100 range, so both code paths behave identically to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue navigation now respects shuffle and repeat-all modes for accurate next/previous track indication.
  * Playback preferences (shuffle and repeat modes) are now persisted and restored on app startup.
  * Skip navigation honors shuffle and repeat settings for improved playback behavior.

* **Bug Fixes**
  * Prevents concurrent background downloads with user feedback.
  * Improved incomplete download detection and cleanup to prevent corrupted files from being treated as valid.
  * Enhanced UPnP volume synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->