### PR TITLE
fix: eliminate UPnP hardware volume overlay jump

### DIFF
--- a/android/app/src/main/kotlin/com/musly/musly/MusicService.kt
+++ b/android/app/src/main/kotlin/com/musly/musly/MusicService.kt
@@ -23,6 +23,7 @@ import android.util.Log
 import androidx.media.VolumeProviderCompat
 import kotlinx.coroutines.*
 import java.net.URL
+import kotlin.math.roundToInt
 
 class MusicService : MediaBrowserServiceCompat() {
 
@@ -60,6 +61,7 @@ class MusicService : MediaBrowserServiceCompat() {
     private var currentPosition: Long = 0
     private var isPlaying: Boolean = false
     private var volumeProvider: VolumeProviderCompat? = null
+    private var upnpExpectedVolume = 0
 
     private val mediaItems = mutableListOf<MediaBrowserCompat.MediaItem>()
     private val recentSongs = mutableListOf<MediaBrowserCompat.MediaItem>()
@@ -688,24 +690,25 @@ class MusicService : MediaBrowserServiceCompat() {
 
     fun setRemoteVolume(isRemote: Boolean, currentVolume: Int) {
         if (isRemote) {
+            // Provider scale 0-20 (1 unit = 5% UPnP). Android's mOptimisticVolume always
+            // steps by ±1, so this aligns the optimistic value with our actual target and
+            // eliminates the 1-second visual jump on hardware volume button presses.
+            val initialProviderVolume = (currentVolume / 5.0).roundToInt().coerceIn(0, 20)
+            upnpExpectedVolume = initialProviderVolume
             volumeProvider = object : VolumeProviderCompat(
-                VOLUME_CONTROL_ABSOLUTE, 100, currentVolume
+                VOLUME_CONTROL_ABSOLUTE, 20, initialProviderVolume
             ) {
                 override fun onSetVolumeTo(volume: Int) {
+                    upnpExpectedVolume = volume
                     setCurrentVolume(volume)
-                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to volume))
+                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to volume * 5))
                 }
 
                 override fun onAdjustVolume(direction: Int) {
-                    // Use getCurrentVolume() (the live VolumeProviderCompat
-                    // property) not the captured constructor param.  The param
-                    // is a val fixed at connection time, so every relative
-                    // adjustment would always compute from the same baseline,
-                    // causing the volume to snap back to initialVolume±5 no
-                    // matter how many times the user presses the button.
-                    val newVolume = (getCurrentVolume() + direction * 5).coerceIn(0, 100)
-                    setCurrentVolume(newVolume)
-                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to newVolume))
+                    if (direction == 0) return  // ADJUST_SAME on key-up; no change needed
+                    upnpExpectedVolume = (upnpExpectedVolume + direction).coerceIn(0, 20)
+                    setCurrentVolume(upnpExpectedVolume)
+                    AndroidAutoPlugin.sendCommand("setVolume", mapOf("volume" to upnpExpectedVolume * 5))
                 }
             }
             mediaSession.setPlaybackToRemote(volumeProvider!!)
@@ -718,7 +721,10 @@ class MusicService : MediaBrowserServiceCompat() {
     }
 
     fun updateRemoteVolume(volume: Int) {
-        volumeProvider?.currentVolume = volume
+        // volume is SOAP scale 0-100; convert to provider scale 0-20
+        val providerVolume = (volume / 5.0).roundToInt().coerceIn(0, 20)
+        upnpExpectedVolume = providerVolume
+        volumeProvider?.currentVolume = providerVolume
     }
 
     override fun onDestroy() {

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1443,11 +1443,33 @@ class PlayerProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool _upnpVolumeWriteInProgress = false;
+
   void _onRemoteVolumeChange(int volume) {
     if (_castService.isConnected) {
       _castService.setVolume(volume / 100.0);
     } else if (_upnpService.isConnected) {
-      _upnpService.setVolume(volume);
+      if (_upnpVolumeWriteInProgress) return;
+      _applyUpnpVolume(volume);
+    }
+  }
+
+  Future<void> _applyUpnpVolume(int volume) async {
+    _upnpVolumeWriteInProgress = true;
+    _volume = (volume / 100.0).clamp(0.0, 1.0);
+    notifyListeners();
+    try {
+      await _upnpService.setVolume(volume);
+      final actual = await _upnpService.getVolume();
+      if (actual >= 0) {
+        _volume = actual / 100.0;
+        _androidSystemService.updateRemoteVolume(actual);
+        notifyListeners();
+      }
+    } catch (e) {
+      debugPrint('UPnP setVolume error: $e');
+    } finally {
+      _upnpVolumeWriteInProgress = false;
     }
   }
 
@@ -1726,16 +1748,11 @@ class PlayerProvider extends ChangeNotifier {
     }
 
     final vol = _upnpService.volume;
-    if (vol >= 0) {
+    if (vol >= 0 && !_upnpVolumeWriteInProgress) {
       final normalized = vol / 100.0;
       if ((_volume - normalized).abs() > 0.005) {
         _volume = normalized;
         changed = true;
-        // Only push the new volume to the Android MediaSession when it has
-        // actually changed.  Calling updateRemoteVolume unconditionally on
-        // every state tick would overwrite any in-flight physical volume
-        // adjustment with the stale cached value before the next poll cycle
-        // had a chance to read it back, causing the audible snap-back.
         _androidSystemService.updateRemoteVolume(vol);
       }
     }


### PR DESCRIPTION
## Problem

When pressing a hardware volume button during UPnP remote playback, Android's `MediaSessionRecord` sets `mOptimisticVolume = currentVolume + direction` (direction is always ±1) and holds it for 1 second before reconciling with `mCurrentVolume`. With `maxVolume=100`, each hardware press optimistically advanced by 1 unit (1%) while our actual UPnP step was 5 units (5%), causing the Android volume overlay to briefly flash the small increment then visually jump to the real value after ~1 second.

## Fix

Set `VolumeProviderCompat` `maxVolume=20` (1 unit = 5% of UPnP range). Now `direction=±1` maps to exactly one 5% step — `mOptimisticVolume` matches our actual target value, Android sees no discrepancy at the 1-second mark, and the jump never fires.

Two additional improvements in the same area:

- **Drop `ADJUST_SAME` (direction=0):** Android fires `onAdjustVolume(0)` on key-up as a "show the overlay" signal with no intended value change. This was causing a redundant SOAP `SetVolume` call. Early return added.

- **Concurrent write guard:** `_upnpVolumeWriteInProgress` prevents rapid button presses from queuing overlapping SOAP exchanges, and stops the poll-based state handler from overwriting the MediaSession volume with a stale cached value while a write is already in-flight.

## Files changed

- `android/app/src/main/kotlin/com/musly/musly/MusicService.kt` — `maxVolume=20`, `upnpExpectedVolume` field to track provider-scale state, `direction==0` early return, scale conversion in `updateRemoteVolume`
- `lib/providers/player_provider.dart` — `_upnpVolumeWriteInProgress` flag, `_applyUpnpVolume` (coordinates `setVolume` + `getVolume` + `updateRemoteVolume` atomically), concurrent guard in `_onRemoteVolumeChange` and poll handler

## Compatibility

Chromecast and Android Auto are unaffected. The `sendCommand("setVolume", value * 5)` call keeps the Dart side always receiving values in the 0–100 range, so both paths behave identically to before.