### PR TITLE
fix: shuffle back button tracks playback history

### DIFF
--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -51,7 +51,7 @@ class PlayerProvider extends ChangeNotifier {
   bool _isPlaying = false;
   bool _isLoading = false;
   bool _shuffleEnabled = false;
-  final List<int> _shuffleHistory = [];
+  final List<String> _shuffleHistory = [];
   RepeatMode _repeatMode = RepeatMode.off;
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
@@ -698,13 +698,15 @@ class PlayerProvider extends ChangeNotifier {
   Duration get duration => _duration;
   Song? get currentSong => _currentSong;
   bool get hasNext =>
-      _currentIndex < _queue.length - 1 ||
-      _repeatMode == RepeatMode.all ||
-      (_shuffleEnabled && _queue.length > 1);
+      _queue.isNotEmpty &&
+      (_currentIndex < _queue.length - 1 ||
+          _repeatMode == RepeatMode.all ||
+          (_shuffleEnabled && _queue.length > 1));
   bool get hasPrevious =>
-      _currentIndex > 0 ||
-      _repeatMode == RepeatMode.all ||
-      (_shuffleEnabled && _queue.length > 1);
+      _queue.isNotEmpty &&
+      (_currentIndex > 0 ||
+          _repeatMode == RepeatMode.all ||
+          (_shuffleEnabled && _shuffleHistory.isNotEmpty));
   double get volume => _volume;
 
   RadioStation? get currentRadioStation => _currentRadioStation;
@@ -840,7 +842,7 @@ class PlayerProvider extends ChangeNotifier {
 
         if (state.processingState == ProcessingState.completed) {
           debugPrint('[Player] ✓ Song completed: "${_currentSong?.title ?? 'unknown'}"');
-          _onSongComplete();
+          _onSongComplete().catchError((e) => debugPrint('[Player] _onSongComplete error: $e'));
         }
 
         if (state.processingState == ProcessingState.buffering && !wasPlaying) {
@@ -908,8 +910,7 @@ class PlayerProvider extends ChangeNotifier {
     );
   }
 
-  void _onSongComplete() {
-    
+  Future<void> _onSongComplete() async {
     if (_currentSong != null && _currentSong!.isLocal != true) {
       _subsonicService.scrobble(_currentSong!.id, submission: true).catchError((
         e,
@@ -936,14 +937,14 @@ class PlayerProvider extends ChangeNotifier {
     // "same song = togglePlayPause" guard and pausing instead of replaying)
     if (_repeatMode == RepeatMode.one ||
         (_repeatMode == RepeatMode.all && _queue.length == 1)) {
-      seek(Duration.zero);
-      play();
+      await seek(Duration.zero);
+      await play();
     } else if (_currentIndex < _queue.length - 1 ||
         _repeatMode == RepeatMode.all ||
         _shuffleEnabled) {
-      skipNext();
+      await skipNext();
     } else {
-      _handleEndOfQueue();
+      await _handleEndOfQueue();
     }
   }
 
@@ -1305,7 +1306,7 @@ class PlayerProvider extends ChangeNotifier {
     }
 
     if (_shuffleEnabled && _queue.length > 1) {
-      _shuffleHistory.add(_currentIndex);
+      _shuffleHistory.add(_currentSong!.id);
       if (_shuffleHistory.length > 50) _shuffleHistory.removeAt(0);
       int next;
       do {
@@ -1315,7 +1316,12 @@ class PlayerProvider extends ChangeNotifier {
     } else if (_currentIndex < _queue.length - 1) {
       await skipToIndex(_currentIndex + 1);
     } else if (_repeatMode == RepeatMode.all) {
-      await skipToIndex(0);
+      if (_queue.length == 1) {
+        await seek(Duration.zero);
+        await play();
+      } else {
+        await skipToIndex(0);
+      }
     }
   }
 
@@ -1343,12 +1349,18 @@ class PlayerProvider extends ChangeNotifier {
     if (_position.inSeconds > 3) {
       await seek(Duration.zero);
     } else if (_shuffleEnabled && _shuffleHistory.isNotEmpty) {
-      final prev = _shuffleHistory.removeLast();
-      await skipToIndex(prev);
+      final prevId = _shuffleHistory.removeLast();
+      final prev = _queue.indexWhere((s) => s.id == prevId);
+      if (prev != -1) await skipToIndex(prev);
     } else if (_currentIndex > 0) {
       await skipToIndex(_currentIndex - 1);
     } else if (_repeatMode == RepeatMode.all && _queue.isNotEmpty) {
-      await skipToIndex(_queue.length - 1);
+      if (_queue.length == 1) {
+        await seek(Duration.zero);
+        await play();
+      } else {
+        await skipToIndex(_queue.length - 1);
+      }
     } else {
       await seek(Duration.zero);
     }
@@ -1735,7 +1747,7 @@ class PlayerProvider extends ChangeNotifier {
       // the transport is stopped, which would cause the check to silently fail.
       debugPrint('UPnP: Track ended (pos=${pos.inSeconds}s, dur=${dur.inSeconds}s) — advancing');
       _upnpWasPlaying = false;
-      _onSongComplete();
+      _onSongComplete().catchError((e) => debugPrint('[Player] _onSongComplete error: $e'));
       return;
     }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' show Random;
 
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -50,6 +51,7 @@ class PlayerProvider extends ChangeNotifier {
   bool _isPlaying = false;
   bool _isLoading = false;
   bool _shuffleEnabled = false;
+  final List<int> _shuffleHistory = [];
   RepeatMode _repeatMode = RepeatMode.off;
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
@@ -695,8 +697,14 @@ class PlayerProvider extends ChangeNotifier {
   Duration get position => _position;
   Duration get duration => _duration;
   Song? get currentSong => _currentSong;
-  bool get hasNext => _currentIndex < _queue.length - 1;
-  bool get hasPrevious => _currentIndex > 0;
+  bool get hasNext =>
+      _currentIndex < _queue.length - 1 ||
+      _repeatMode == RepeatMode.all ||
+      (_shuffleEnabled && _queue.length > 1);
+  bool get hasPrevious =>
+      _currentIndex > 0 ||
+      _repeatMode == RepeatMode.all ||
+      (_shuffleEnabled && _queue.length > 1);
   double get volume => _volume;
 
   RadioStation? get currentRadioStation => _currentRadioStation;
@@ -801,10 +809,19 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   void _initializePlayer() {
-    
     _storageService.getVolume().then((savedVolume) {
       _volume = savedVolume;
       _audioPlayer.setVolume(_volume);
+      notifyListeners();
+    });
+
+    _storageService.getShuffleMode().then((saved) {
+      _shuffleEnabled = saved;
+      notifyListeners();
+    });
+
+    _storageService.getRepeatMode().then((saved) {
+      _repeatMode = RepeatMode.values[saved.clamp(0, RepeatMode.values.length - 1)];
       notifyListeners();
     });
 
@@ -914,26 +931,19 @@ class PlayerProvider extends ChangeNotifier {
       return;
     }
 
-    switch (_repeatMode) {
-      case RepeatMode.one:
-        seek(Duration.zero);
-        play();
-        break;
-      case RepeatMode.all:
-        if (_currentIndex >= _queue.length - 1) {
-          skipToIndex(0);
-        } else {
-          skipNext();
-        }
-        break;
-      case RepeatMode.off:
-        if (_currentIndex < _queue.length - 1) {
-          skipNext();
-        } else {
-          
-          _handleEndOfQueue();
-        }
-        break;
+    // Repeat-one, or repeat-all with a single-song queue: seek and replay
+    // (skipNext would call playSong with the same song, triggering the
+    // "same song = togglePlayPause" guard and pausing instead of replaying)
+    if (_repeatMode == RepeatMode.one ||
+        (_repeatMode == RepeatMode.all && _queue.length == 1)) {
+      seek(Duration.zero);
+      play();
+    } else if (_currentIndex < _queue.length - 1 ||
+        _repeatMode == RepeatMode.all ||
+        _shuffleEnabled) {
+      skipNext();
+    } else {
+      _handleEndOfQueue();
     }
   }
 
@@ -966,13 +976,16 @@ class PlayerProvider extends ChangeNotifier {
 
     try {
       if (playlist != null) {
+        final isNewQueue = !identical(playlist, _queue);
         _queue = List.from(playlist);
         _currentIndex =
             startIndex ?? playlist.indexWhere((s) => s.id == song.id);
         if (_currentIndex == -1) _currentIndex = 0;
+        if (isNewQueue) _shuffleHistory.clear();
       } else if (_queue.isEmpty || !_queue.any((s) => s.id == song.id)) {
         _queue = [song];
         _currentIndex = 0;
+        _shuffleHistory.clear();
       } else {
         _currentIndex = _queue.indexWhere((s) => s.id == song.id);
       }
@@ -1291,8 +1304,18 @@ class PlayerProvider extends ChangeNotifier {
       await _addAutoDjSongs();
     }
 
-    if (_currentIndex < _queue.length - 1) {
+    if (_shuffleEnabled && _queue.length > 1) {
+      _shuffleHistory.add(_currentIndex);
+      if (_shuffleHistory.length > 50) _shuffleHistory.removeAt(0);
+      int next;
+      do {
+        next = Random().nextInt(_queue.length);
+      } while (next == _currentIndex);
+      await skipToIndex(next);
+    } else if (_currentIndex < _queue.length - 1) {
       await skipToIndex(_currentIndex + 1);
+    } else if (_repeatMode == RepeatMode.all) {
+      await skipToIndex(0);
     }
   }
 
@@ -1319,8 +1342,13 @@ class PlayerProvider extends ChangeNotifier {
   Future<void> skipPrevious() async {
     if (_position.inSeconds > 3) {
       await seek(Duration.zero);
+    } else if (_shuffleEnabled && _shuffleHistory.isNotEmpty) {
+      final prev = _shuffleHistory.removeLast();
+      await skipToIndex(prev);
     } else if (_currentIndex > 0) {
       await skipToIndex(_currentIndex - 1);
+    } else if (_repeatMode == RepeatMode.all && _queue.isNotEmpty) {
+      await skipToIndex(_queue.length - 1);
     } else {
       await seek(Duration.zero);
     }
@@ -1334,6 +1362,7 @@ class PlayerProvider extends ChangeNotifier {
 
   void toggleShuffle() {
     _shuffleEnabled = !_shuffleEnabled;
+    _shuffleHistory.clear();
     if (_shuffleEnabled && _queue.length > 1 && _currentSong != null) {
       final currentSong = _currentSong!;
       _queue.shuffle();
@@ -1341,6 +1370,7 @@ class PlayerProvider extends ChangeNotifier {
       _queue.insert(0, currentSong);
       _currentIndex = 0;
     }
+    _storageService.saveShuffleMode(_shuffleEnabled);
     notifyListeners();
   }
 
@@ -1356,6 +1386,7 @@ class PlayerProvider extends ChangeNotifier {
         _repeatMode = RepeatMode.off;
         break;
     }
+    _storageService.saveRepeatMode(_repeatMode.index);
     notifyListeners();
   }
 


### PR DESCRIPTION
## Problem

Pressing the back button during shuffle mode doesn't return to the song that was actually playing before. Instead it navigates by queue array index (`index - 1`), so it either lands on a completely unrelated song or wraps to a new random track at queue boundaries. There is no memory of what was played.

## Solution

Adds a `_shuffleHistory` stack (capped at 50 entries) in `PlayerProvider`. Every forward skip — whether from a manual next press, auto-advance at song end, or an external control (Bluetooth headset, Garmin, etc.) — pushes the current index before jumping to a random one. `skipPrevious` pops from the stack when shuffle is on and history exists, replaying the exact sequence in reverse.

History is preserved during internal navigation (same queue reference via `identical()`) but cleared when the user loads a new queue or toggles shuffle off.

**Bundled fixes in the same file:**
- `repeat-all` with a single-song queue would pause instead of looping — `skipNext` called `playSong` with the same song, hitting the `togglePlayPause` guard and pausing instead of replaying. Now treated identically to `repeat-one`: seek to zero and play directly.
- `hasNext`/`hasPrevious` now correctly return `true` in shuffle mode and under repeat-all, so the UI never incorrectly disables navigation buttons.
- `skipNext`/`skipPrevious` wrap at queue boundaries under repeat-all.
- Shuffle enabled state and repeat mode are now persisted across app restarts via the existing `StorageService` methods.

## Files changed

- `lib/providers/player_provider.dart` — 1 file, +55/−24 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playback navigation now respects shuffle and repeat modes (including repeat-all and repeat-one) when determining next/previous tracks.
  * Previous/next behavior updated to use shuffle history for accurate back/forward navigation.
  * End-of-track handling improved to correctly replay, advance, or end queue based on current modes.
  * Shuffle history is cleared appropriately when starting new queues or single-track playback.
  * Shuffle and repeat settings now persist across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->