### PR TITLE
fix: auto-disconnect UPnP renderer after 30 s of connectivity loss

### DIFF
--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -89,6 +89,7 @@ class PlayerProvider extends ChangeNotifier {
     _discordRpcService = DiscordRpcService(storageService);
     _castService.addListener(_onCastStateChanged);
     _upnpService.addListener(_onUpnpStateChanged);
+    _upnpService.onRendererLost = _onUpnpRendererLost;
     _initializePlayer();
     _initializeAndroidAuto();
     _initializeSystemServices();
@@ -188,10 +189,21 @@ class PlayerProvider extends ChangeNotifier {
     _bluetoothService.onSeekTo = seek;
     _bluetoothService.onDeviceConnected = (device) {
       debugPrint('Bluetooth device connected: ${device.name}');
+      // AVRCP support means the device can handle audio controls, which is
+      // a reliable proxy for A2DP audio output (watches/controllers don't
+      // advertise AVRCP). Re-query isA2dpConnected for ground truth.
+      _bluetoothService.isA2dpConnected().then((active) {
+        _isA2dpAudioActive = active;
+        debugPrint('Bluetooth A2DP audio active: $_isA2dpAudioActive');
+      });
       _updateAllServices();
     };
     _bluetoothService.onDeviceDisconnected = (device) {
       debugPrint('Bluetooth device disconnected: ${device.name}');
+      _bluetoothService.isA2dpConnected().then((active) {
+        _isA2dpAudioActive = active;
+        debugPrint('Bluetooth A2DP audio active: $_isA2dpAudioActive');
+      });
     };
     
     _bluetoothService.registerAbsoluteVolumeControl();
@@ -1652,6 +1664,9 @@ class PlayerProvider extends ChangeNotifier {
 
   bool _upnpWasConnected = false;
   bool _upnpWasPlaying = false;
+  // True when an A2DP audio-output device (car, speaker) is connected.
+  // Control-only devices (Garmin watch, etc.) don't set this flag.
+  bool _isA2dpAudioActive = false;
 
   void _onUpnpStateChanged() {
     final connected = _upnpService.isConnected;
@@ -1681,8 +1696,7 @@ class PlayerProvider extends ChangeNotifier {
       _upnpWasPlaying = false;
       _isRenderingRemotely = false;
       _isPlaying = false;
-      _position = Duration.zero;
-      _duration = Duration.zero;
+      // Preserve _position and _duration so the UI shows where we were.
       _androidSystemService.setRemotePlayback(isRemote: false);
       notifyListeners();
       _updateAndroidAuto();
@@ -1745,5 +1759,33 @@ class PlayerProvider extends ChangeNotifier {
       notifyListeners();
       _updateAndroidAuto();
     }
+  }
+
+  /// Called by [UpnpService] after 30 consecutive poll failures (~30 s).
+  /// [_onUpnpStateChanged] has already switched us off remote playback and
+  /// preserved [_position]. Load the song into the local player at the last
+  /// known position, paused, so the user can resume wherever they want.
+  /// Android routes audio to a connected A2DP device automatically.
+  void _onUpnpRendererLost() {
+    final lastPosition = _position;
+    final lastSong = _currentSong;
+
+    debugPrint(
+      'UPnP: renderer lost — A2DP audio active: $_isA2dpAudioActive, '
+      'last position: ${lastPosition.inSeconds}s, song: "${lastSong?.title}"',
+    );
+
+    if (lastSong == null) return;
+
+    final playUrl = lastSong.isLocal == true && lastSong.path != null
+        ? Uri.file(lastSong.path!).toString()
+        : _offlineService.getPlayableUrl(lastSong, _subsonicService);
+
+    _audioPlayer.setUrl(playUrl).then((_) async {
+      await _audioPlayer.seek(lastPosition);
+      // Leave paused — let the user consciously resume on their new output.
+    }).catchError((e) {
+      debugPrint('UPnP fallback: failed to reload local player: $e');
+    });
   }
 }

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1564,6 +1564,9 @@ class PlayerProvider extends ChangeNotifier {
     _sleepTimerFadeTimer?.cancel();
     _castService.removeListener(_onCastStateChanged);
     _upnpService.removeListener(_onUpnpStateChanged);
+    if (_upnpService.onRendererLost == _onUpnpRendererLost) {
+      _upnpService.onRendererLost = null;
+    }
     _audioHandler.customAction('dispose');
     _androidAutoService.dispose();
     _androidSystemService.dispose();
@@ -1766,7 +1769,7 @@ class PlayerProvider extends ChangeNotifier {
   /// preserved [_position]. Load the song into the local player at the last
   /// known position, paused, so the user can resume wherever they want.
   /// Android routes audio to a connected A2DP device automatically.
-  void _onUpnpRendererLost() {
+  Future<void> _onUpnpRendererLost() async {
     final lastPosition = _position;
     final lastSong = _currentSong;
 
@@ -1781,11 +1784,20 @@ class PlayerProvider extends ChangeNotifier {
         ? Uri.file(lastSong.path!).toString()
         : _offlineService.getPlayableUrl(lastSong, _subsonicService);
 
-    _audioPlayer.setUrl(playUrl).then((_) async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      await _audioPlayer.setUrl(playUrl);
+      _position = lastPosition;
       await _audioPlayer.seek(lastPosition);
       // Leave paused — let the user consciously resume on their new output.
-    }).catchError((e) {
+    } catch (e) {
       debugPrint('UPnP fallback: failed to reload local player: $e');
-    });
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+      _updateAndroidAuto();
+    }
   }
 }

--- a/lib/services/upnp_service.dart
+++ b/lib/services/upnp_service.dart
@@ -61,6 +61,10 @@ class UpnpService extends ChangeNotifier {
   int get volume => _volume;
   int get consecutivePollErrors => _consecutivePollErrors;
 
+  /// Called when the renderer becomes unreachable after 30 consecutive poll
+  /// failures (~30 s). The service has already called disconnect() internally.
+  VoidCallback? onRendererLost;
+
   List<UpnpDevice> get devices => List.unmodifiable(_devices);
   UpnpDevice? get connectedDevice => _connectedDevice;
   bool get isConnected => _connectedDevice != null;
@@ -297,7 +301,6 @@ class UpnpService extends ChangeNotifier {
       final state = await getPlaybackState();
       if (state == null) {
         // getPlaybackState() caught an exception internally and returned null.
-        // Count consecutive failures so callers can detect a dead renderer.
         _consecutivePollErrors++;
         notifyListeners();
         if (_consecutivePollErrors == 1 || _consecutivePollErrors % 5 == 0) {
@@ -305,6 +308,14 @@ class UpnpService extends ChangeNotifier {
             'UPnP: poll failed $_consecutivePollErrors time(s) in a row '
             '— renderer may be unreachable',
           );
+        }
+        // 30 consecutive failures (~30 s) — treat the renderer as gone.
+        // Network hiccups and AP roaming typically resolve within 10–15 s,
+        // so 30 s gives enough headroom without leaving the user stuck.
+        if (_consecutivePollErrors >= 30) {
+          debugPrint('UPnP: 30 consecutive poll failures — auto-disconnecting renderer');
+          disconnect();
+          onRendererLost?.call();
         }
         return;
       }

--- a/lib/services/upnp_service.dart
+++ b/lib/services/upnp_service.dart
@@ -239,14 +239,15 @@ class UpnpService extends ChangeNotifier {
 
   Future<bool> connect(UpnpDevice device) async {
     try {
-      
+
       await _soap(device.avTransportUrl, 'GetTransportInfo', '');
       _connectedDevice = device;
       debugPrint('UPnP: Connected to ${device.friendlyName}');
-      
+
       if (device.renderingControlUrl != null) {
         _volume = await getVolume();
       }
+      _consecutivePollErrors = 0;
       _startPolling();
       notifyListeners();
       return true;
@@ -265,6 +266,7 @@ class UpnpService extends ChangeNotifier {
     _rendererPosition = Duration.zero;
     _rendererDuration = Duration.zero;
     _volume = -1;
+    _consecutivePollErrors = 0;
     notifyListeners();
 
     if (device != null) {
@@ -354,6 +356,11 @@ class UpnpService extends ChangeNotifier {
       _consecutivePollErrors++;
       notifyListeners();
       debugPrint('UPnP: poll error: $e');
+      if (_consecutivePollErrors >= 30) {
+        debugPrint('UPnP: 30 consecutive poll failures — auto-disconnecting renderer');
+        disconnect();
+        onRendererLost?.call();
+      }
     } finally {
       _isPolling = false;
     }


### PR DESCRIPTION
## Problem

When a UPnP/DLNA renderer goes out of WiFi range (or the network drops), the app continues trying to cast to it indefinitely. Playback stalls and the UI shows the renderer as still connected. The only escape is manually tapping Disconnect — there is no automatic recovery.

## Solution

`UpnpService` already polls the renderer every second and counts consecutive `GetTransportInfo` failures in `_consecutivePollErrors`. After **30 consecutive failures (~30 s)** it now:
1. Calls `disconnect()` automatically
2. Fires a new `onRendererLost` callback

30 seconds was chosen to survive normal network hiccups and WiFi AP roaming transitions (which typically resolve within 10–15 s) without leaving the user stuck for minutes.

`PlayerProvider` wires `onRendererLost` to `_onUpnpRendererLost`, which:
- **Preserves** the last known playback position instead of zeroing it on disconnect
- **Reloads** the current song into the local audio player seeked to that position, paused — the user can tap play on whatever output they want (phone speaker, Bluetooth car/speaker)
- **Tracks** whether a Bluetooth A2DP audio device is connected via `isA2dpConnected()` on each BT connect/disconnect event; Android routes local audio to it automatically, so no additional switching is needed on the Dart side

## Files changed

- `lib/services/upnp_service.dart` — add `onRendererLost` callback, trigger auto-disconnect at 30 consecutive poll failures
- `lib/providers/player_provider.dart` — wire callback, preserve position on disconnect, reload local player on renderer loss, track A2DP audio presence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playback position no longer resets to zero when a UPnP renderer disconnects; UI retains last known location.
  * More reliable detection of renderer loss prevents silent playback drops.

* **Improvements**
  * App now attempts a paused local fallback and restores the last track and position when a renderer is lost.
  * Better Bluetooth A2DP connection tracking for improved playback state awareness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->