### PR TITLE
feat: offline download management — playlist/album download, cancel, remove, and offline art

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    FLUTTER_SUPPRESS_ANALYTICS=1 \
+    PUB_CACHE=/opt/pub-cache \
+    GRADLE_USER_HOME=/opt/gradle-cache
+
+# ── System deps ────────────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openjdk-17-jdk-headless \
+        wget curl git unzip xz-utils zip \
+        libglu1-mesa ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
+    PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
+
+# ── Android SDK (including cmake so Gradle never tries to auto-install it) ─────
+ENV ANDROID_SDK_ROOT=/opt/android-sdk \
+    ANDROID_HOME=/opt/android-sdk
+RUN mkdir -p /opt/android-sdk/cmdline-tools \
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+             -O /tmp/cmdline-tools.zip \
+    && unzip -q /tmp/cmdline-tools.zip -d /opt/android-sdk/cmdline-tools \
+    && mv /opt/android-sdk/cmdline-tools/cmdline-tools \
+          /opt/android-sdk/cmdline-tools/latest \
+    && rm /tmp/cmdline-tools.zip
+
+ENV PATH=/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:$PATH
+
+RUN yes | sdkmanager --licenses > /dev/null 2>&1 || true \
+    && sdkmanager \
+        "platform-tools" \
+        "platforms;android-35" \
+        "build-tools;35.0.0" \
+        "ndk;27.0.12077973" \
+        "cmake;3.22.1"
+
+# ── Flutter SDK ────────────────────────────────────────────────────────────────
+RUN git clone --depth 1 --branch stable \
+        https://github.com/flutter/flutter.git /opt/flutter \
+    && git config --global --add safe.directory /opt/flutter
+
+ENV PATH=/opt/flutter/bin:$PATH
+
+RUN flutter --version
+RUN yes | flutter doctor --android-licenses > /dev/null 2>&1 || true
+
+# ── App source & build ─────────────────────────────────────────────────────────
+WORKDIR /app
+COPY . .
+
+# Cache mounts keep Gradle + pub downloads outside the overlay layer,
+# preventing "No space left on device" errors on large Gradle transform sets.
+RUN --mount=type=cache,target=/opt/gradle-cache \
+    --mount=type=cache,target=/opt/pub-cache \
+    flutter pub get
+
+RUN --mount=type=cache,target=/opt/gradle-cache \
+    --mount=type=cache,target=/opt/pub-cache \
+    flutter build apk --release
+
+# Output: /app/build/app/outputs/flutter-apk/app-release.apk

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+android.newDsl=false

--- a/build-release-apk.sh
+++ b/build-release-apk.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build a release APK using Docker (data stored in /rw/docker).
+# Usage:  ./build-release-apk.sh [output-dir]
+# The APK is copied to <output-dir> (default: ./release-apk)
+set -euo pipefail
+
+OUTPUT_DIR="${1:-$(pwd)/release-apk}"
+IMAGE_TAG="musly-release-builder"
+CONTAINER_NAME="musly-apk-build"
+
+cd "$(dirname "$0")"
+
+echo "==> Building Docker image: $IMAGE_TAG"
+sudo docker build -f Dockerfile.release -t "$IMAGE_TAG" .
+
+echo "==> Extracting APK from image"
+sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+sudo docker create --name "$CONTAINER_NAME" "$IMAGE_TAG" echo done
+mkdir -p "$OUTPUT_DIR"
+sudo docker cp \
+    "$CONTAINER_NAME:/app/build/app/outputs/flutter-apk/app-release.apk" \
+    "$OUTPUT_DIR/musly-release.apk"
+sudo docker rm -f "$CONTAINER_NAME"
+
+echo ""
+echo "==> APK ready: $OUTPUT_DIR/musly-release.apk"
+ls -lh "$OUTPUT_DIR/musly-release.apk"

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -887,7 +887,11 @@ class PlayerProvider extends ChangeNotifier {
       return;
     }
 
-    if (_repeatMode == RepeatMode.one) {
+    // Repeat-one, or repeat-all with a single-song queue: seek and replay
+    // (skipNext would call playSong with the same song, triggering the
+    // "same song = togglePlayPause" guard and pausing instead of replaying)
+    if (_repeatMode == RepeatMode.one ||
+        (_repeatMode == RepeatMode.all && _queue.length == 1)) {
       seek(Duration.zero);
       play();
     } else if (_currentIndex < _queue.length - 1 ||

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' show Random;
 
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -676,8 +677,14 @@ class PlayerProvider extends ChangeNotifier {
   Duration get position => _position;
   Duration get duration => _duration;
   Song? get currentSong => _currentSong;
-  bool get hasNext => _currentIndex < _queue.length - 1;
-  bool get hasPrevious => _currentIndex > 0;
+  bool get hasNext =>
+      _currentIndex < _queue.length - 1 ||
+      _repeatMode == RepeatMode.all ||
+      (_shuffleEnabled && _queue.length > 1);
+  bool get hasPrevious =>
+      _currentIndex > 0 ||
+      _repeatMode == RepeatMode.all ||
+      (_shuffleEnabled && _queue.length > 1);
   double get volume => _volume;
 
   RadioStation? get currentRadioStation => _currentRadioStation;
@@ -770,10 +777,19 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   void _initializePlayer() {
-    
     _storageService.getVolume().then((savedVolume) {
       _volume = savedVolume;
       _audioPlayer.setVolume(_volume);
+      notifyListeners();
+    });
+
+    _storageService.getShuffleMode().then((saved) {
+      _shuffleEnabled = saved;
+      notifyListeners();
+    });
+
+    _storageService.getRepeatMode().then((saved) {
+      _repeatMode = RepeatMode.values[saved.clamp(0, RepeatMode.values.length - 1)];
       notifyListeners();
     });
 
@@ -927,6 +943,13 @@ class PlayerProvider extends ChangeNotifier {
         _currentIndex =
             startIndex ?? playlist.indexWhere((s) => s.id == song.id);
         if (_currentIndex == -1) _currentIndex = 0;
+        // Apply shuffle to the new queue, keeping the chosen song at front
+        if (_shuffleEnabled && _queue.length > 1) {
+          _queue.shuffle();
+          _queue.remove(song);
+          _queue.insert(0, song);
+          _currentIndex = 0;
+        }
       } else if (_queue.isEmpty || !_queue.any((s) => s.id == song.id)) {
         _queue = [song];
         _currentIndex = 0;
@@ -1239,6 +1262,14 @@ class PlayerProvider extends ChangeNotifier {
 
     if (_currentIndex < _queue.length - 1) {
       await skipToIndex(_currentIndex + 1);
+    } else if (_repeatMode == RepeatMode.all) {
+      await skipToIndex(0);
+    } else if (_shuffleEnabled && _queue.length > 1) {
+      int next;
+      do {
+        next = Random().nextInt(_queue.length);
+      } while (next == _currentIndex);
+      await skipToIndex(next);
     }
   }
 
@@ -1267,6 +1298,14 @@ class PlayerProvider extends ChangeNotifier {
       await seek(Duration.zero);
     } else if (_currentIndex > 0) {
       await skipToIndex(_currentIndex - 1);
+    } else if (_repeatMode == RepeatMode.all && _queue.isNotEmpty) {
+      await skipToIndex(_queue.length - 1);
+    } else if (_shuffleEnabled && _queue.length > 1) {
+      int prev;
+      do {
+        prev = Random().nextInt(_queue.length);
+      } while (prev == _currentIndex);
+      await skipToIndex(prev);
     } else {
       await seek(Duration.zero);
     }
@@ -1287,6 +1326,7 @@ class PlayerProvider extends ChangeNotifier {
       _queue.insert(0, currentSong);
       _currentIndex = 0;
     }
+    _storageService.saveShuffleMode(_shuffleEnabled);
     notifyListeners();
   }
 
@@ -1302,6 +1342,7 @@ class PlayerProvider extends ChangeNotifier {
         _repeatMode = RepeatMode.off;
         break;
     }
+    _storageService.saveRepeatMode(_repeatMode.index);
     notifyListeners();
   }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -819,6 +819,12 @@ class PlayerProvider extends ChangeNotifier {
       notifyListeners();
     });
 
+    // Resume any playlists that were queued for download but interrupted
+    _offlineService.initialize().then((_) {
+      _offlineService.resumeIncompleteDownloads(_subsonicService);
+    });
+
+
     _storageService.getRepeatMode().then((saved) {
       _repeatMode = RepeatMode.values[saved.clamp(0, RepeatMode.values.length - 1)];
       notifyListeners();

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -887,26 +887,15 @@ class PlayerProvider extends ChangeNotifier {
       return;
     }
 
-    switch (_repeatMode) {
-      case RepeatMode.one:
-        seek(Duration.zero);
-        play();
-        break;
-      case RepeatMode.all:
-        if (_currentIndex >= _queue.length - 1) {
-          skipToIndex(0);
-        } else {
-          skipNext();
-        }
-        break;
-      case RepeatMode.off:
-        if (_currentIndex < _queue.length - 1) {
-          skipNext();
-        } else {
-          
-          _handleEndOfQueue();
-        }
-        break;
+    if (_repeatMode == RepeatMode.one) {
+      seek(Duration.zero);
+      play();
+    } else if (_currentIndex < _queue.length - 1 ||
+        _repeatMode == RepeatMode.all ||
+        _shuffleEnabled) {
+      skipNext();
+    } else {
+      _handleEndOfQueue();
     }
   }
 
@@ -943,13 +932,6 @@ class PlayerProvider extends ChangeNotifier {
         _currentIndex =
             startIndex ?? playlist.indexWhere((s) => s.id == song.id);
         if (_currentIndex == -1) _currentIndex = 0;
-        // Apply shuffle to the new queue, keeping the chosen song at front
-        if (_shuffleEnabled && _queue.length > 1) {
-          _queue.shuffle();
-          _queue.remove(song);
-          _queue.insert(0, song);
-          _currentIndex = 0;
-        }
       } else if (_queue.isEmpty || !_queue.any((s) => s.id == song.id)) {
         _queue = [song];
         _currentIndex = 0;
@@ -1260,16 +1242,16 @@ class PlayerProvider extends ChangeNotifier {
       await _addAutoDjSongs();
     }
 
-    if (_currentIndex < _queue.length - 1) {
-      await skipToIndex(_currentIndex + 1);
-    } else if (_repeatMode == RepeatMode.all) {
-      await skipToIndex(0);
-    } else if (_shuffleEnabled && _queue.length > 1) {
+    if (_shuffleEnabled && _queue.length > 1) {
       int next;
       do {
         next = Random().nextInt(_queue.length);
       } while (next == _currentIndex);
       await skipToIndex(next);
+    } else if (_currentIndex < _queue.length - 1) {
+      await skipToIndex(_currentIndex + 1);
+    } else if (_repeatMode == RepeatMode.all) {
+      await skipToIndex(0);
     }
   }
 

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -86,34 +86,21 @@ class _AlbumScreenState extends State<AlbumScreen> {
     if (_songs.isEmpty) return;
 
     final offlineService = OfflineService();
-    if (offlineService.isBackgroundDownloadActive) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('A download is already in progress'),
-            duration: Duration(seconds: 2),
-          ),
-        );
-      }
-      return;
-    }
-
-    final subsonicService = Provider.of<SubsonicService>(
-      context,
-      listen: false,
-    );
+    final subsonicService = Provider.of<SubsonicService>(context, listen: false);
     await offlineService.initialize();
 
     setState(() => _isDownloading = true);
 
-    offlineService.startBackgroundDownload(_songs, subsonicService).whenComplete(() {
+    offlineService
+        .queuePlaylistDownload(_album!.id, _songs, subsonicService)
+        .whenComplete(() {
       if (mounted) setState(() => _isDownloading = false);
     });
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Downloading ${_songs.length} songs from ${_album!.name} in background…'),
+          content: Text('Queued ${_songs.length} songs from ${_album!.name} for download…'),
           duration: const Duration(seconds: 2),
         ),
       );

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -85,33 +85,35 @@ class _AlbumScreenState extends State<AlbumScreen> {
   Future<void> _downloadAlbum() async {
     if (_songs.isEmpty) return;
 
+    final offlineService = OfflineService();
+    if (offlineService.isBackgroundDownloadActive) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('A download is already in progress'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+
     final subsonicService = Provider.of<SubsonicService>(
       context,
       listen: false,
     );
-    final offlineService = OfflineService();
     await offlineService.initialize();
 
     setState(() => _isDownloading = true);
 
-    offlineService.startBackgroundDownload(_songs, subsonicService).then((_) {
-      if (mounted) {
-        setState(() => _isDownloading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Downloaded ${_songs.length} songs from ${_album!.name}',
-            ),
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
+    offlineService.startBackgroundDownload(_songs, subsonicService).whenComplete(() {
+      if (mounted) setState(() => _isDownloading = false);
     });
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Downloading ${_songs.length} songs in background…'),
+          content: Text('Downloading ${_songs.length} songs from ${_album!.name} in background…'),
           duration: const Duration(seconds: 2),
         ),
       );

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -228,24 +228,47 @@ class _AlbumScreenState extends State<AlbumScreen> {
                   onPressed: () => Navigator.pop(context),
                 ),
                 flexibleSpace: FlexibleSpaceBar(
-                  background: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      Padding(
-                        padding: EdgeInsets.only(
-                          top: MediaQuery.of(context).padding.top + 60,
-                          left: 40,
-                          right: 40,
-                          bottom: 80,
-                        ),
-                        child: AlbumArtwork(
-                          coverArt: _album!.coverArt,
-                          size: 280,
-                          borderRadius: 10,
-                          preserveAspectRatio: true,
-                        ),
-                      ),
-                    ],
+                  background: ValueListenableBuilder<Set<String>>(
+                    valueListenable: OfflineService().downloadedSongIds,
+                    builder: (context, ids, _) {
+                      final allDownloaded = _songs.isNotEmpty &&
+                          _songs.every((s) => ids.contains(s.id));
+                      return Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          Padding(
+                            padding: EdgeInsets.only(
+                              top: MediaQuery.of(context).padding.top + 60,
+                              left: 40,
+                              right: 40,
+                              bottom: 80,
+                            ),
+                            child: AlbumArtwork(
+                              coverArt: _album!.coverArt,
+                              size: 280,
+                              borderRadius: 10,
+                              preserveAspectRatio: true,
+                            ),
+                          ),
+                          if (allDownloaded)
+                            Positioned(
+                              bottom: 86,
+                              right: 46,
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  color: Colors.white,
+                                  shape: BoxShape.circle,
+                                ),
+                                child: const Icon(
+                                  Icons.check_circle,
+                                  color: Colors.green,
+                                  size: 28,
+                                ),
+                              ),
+                            ),
+                        ],
+                      );
+                    },
                   ),
                 ),
                 actions: [

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -24,10 +24,36 @@ class _AlbumScreenState extends State<AlbumScreen> {
   List<Song> _songs = [];
   bool _isLoading = true;
 
+  bool _allDownloaded = false;
+  bool _isQueued = false;
+
   @override
   void initState() {
     super.initState();
     _loadAlbum();
+    OfflineService().downloadedSongIds.addListener(_updateDownloadState);
+    OfflineService().queuedPlaylistIds.addListener(_updateDownloadState);
+  }
+
+  @override
+  void dispose() {
+    OfflineService().downloadedSongIds.removeListener(_updateDownloadState);
+    OfflineService().queuedPlaylistIds.removeListener(_updateDownloadState);
+    super.dispose();
+  }
+
+  void _updateDownloadState() {
+    if (!mounted || _songs.isEmpty) return;
+    final ids = OfflineService().downloadedSongIds.value;
+    final allDown = _songs.every((s) => ids.contains(s.id));
+    final queued = _album != null &&
+        OfflineService().queuedPlaylistIds.value.contains(_album!.id);
+    if (allDown != _allDownloaded || queued != _isQueued) {
+      setState(() {
+        _allDownloaded = allDown;
+        _isQueued = queued;
+      });
+    }
   }
 
   Future<void> _loadAlbum() async {
@@ -60,6 +86,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
           _songs = songs;
           _isLoading = false;
         });
+        _updateDownloadState();
       }
     } catch (e) {
       if (mounted) {
@@ -82,22 +109,71 @@ class _AlbumScreenState extends State<AlbumScreen> {
   }
 
   Future<void> _downloadAlbum() async {
-    if (_songs.isEmpty) return;
-
+    if (_songs.isEmpty || _album == null) return;
     final offlineService = OfflineService();
     final subsonicService = Provider.of<SubsonicService>(context, listen: false);
     await offlineService.initialize();
-
     offlineService.queuePlaylistDownload(_album!.id, _songs, subsonicService);
-
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Queued ${_songs.length} songs from ${_album!.name} for download…'),
+          content: Text('Queued ${_songs.length} songs for download…'),
           duration: const Duration(seconds: 2),
         ),
       );
     }
+  }
+
+  Future<void> _cancelDownload() async {
+    if (_album == null) return;
+    await OfflineService().cancelPlaylistDownload(_album!.id);
+  }
+
+  Future<void> _removeDownloads() async {
+    if (_songs.isEmpty || _album == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Remove downloads?'),
+        content: Text('Remove all ${_songs.length} downloaded songs from "${_album!.name}"?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Remove', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      await OfflineService().deletePlaylistDownloads(_songs.map((s) => s.id).toList());
+    }
+  }
+
+  Widget _buildDownloadButton(BuildContext context) {
+    if (_allDownloaded) {
+      return IconButton(
+        tooltip: 'Downloaded — tap to remove',
+        onPressed: _removeDownloads,
+        icon: const Icon(Icons.cloud_done, color: Colors.green),
+      );
+    }
+    if (_isQueued) {
+      return IconButton(
+        tooltip: 'Downloading — tap to cancel',
+        onPressed: _cancelDownload,
+        icon: const SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return IconButton(
+      tooltip: 'Download album',
+      onPressed: _downloadAlbum,
+      icon: const Icon(CupertinoIcons.cloud_download),
+    );
   }
 
   @override
@@ -252,32 +328,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
                   ),
                 ),
                 actions: [
-                  if (!isOffline)
-                    ValueListenableBuilder<Set<String>>(
-                      valueListenable: OfflineService().queuedPlaylistIds,
-                      builder: (context, queued, _) {
-                        return ValueListenableBuilder<Set<String>>(
-                          valueListenable: OfflineService().downloadedSongIds,
-                          builder: (context, downloaded, _) {
-                            final allDownloaded = _songs.isNotEmpty &&
-                                _songs.every((s) => downloaded.contains(s.id));
-                            final isQueued = queued.contains(_album!.id);
-                            final isSpinning = isQueued && !allDownloaded;
-                            return IconButton(
-                              tooltip: isSpinning ? 'Downloading…' : 'Download album',
-                              onPressed: isSpinning ? null : _downloadAlbum,
-                              icon: isSpinning
-                                  ? const SizedBox(
-                                      width: 20,
-                                      height: 20,
-                                      child: CircularProgressIndicator(strokeWidth: 2),
-                                    )
-                                  : const Icon(CupertinoIcons.cloud_download),
-                            );
-                          },
-                        );
-                      },
-                    ),
+                  if (!isOffline) _buildDownloadButton(context),
                 ],
               ),
               SliverToBoxAdapter(

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -44,10 +44,24 @@ class _AlbumScreenState extends State<AlbumScreen> {
 
   void _updateDownloadState() {
     if (!mounted || _songs.isEmpty) return;
-    final ids = OfflineService().downloadedSongIds.value;
-    final allDown = _songs.every((s) => ids.contains(s.id));
+    final offline = OfflineService();
+    final ids = offline.downloadedSongIds.value;
+    bool allDown = _songs.every((s) => ids.contains(s.id));
     final queued = _album != null &&
-        OfflineService().queuedPlaylistIds.value.contains(_album!.id);
+        offline.queuedPlaylistIds.value.contains(_album!.id);
+    if (!allDown && !queued && _isQueued) {
+      allDown = _songs.every((s) => offline.isSongDownloaded(s.id));
+      if (allDown) {
+        final missing = _songs
+            .where((s) => !ids.contains(s.id))
+            .map((s) => s.id)
+            .toSet();
+        if (missing.isNotEmpty) {
+          offline.downloadedSongIds.value = {...ids, ...missing};
+          return;
+        }
+      }
+    }
     if (allDown != _allDownloaded || queued != _isQueued) {
       setState(() {
         _allDownloaded = allDown;
@@ -146,7 +160,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
       ),
     );
     if (confirmed == true && mounted) {
-      await OfflineService().deletePlaylistDownloads(_songs.map((s) => s.id).toList());
+      await OfflineService().deletePlaylistDownloads(_songs);
     }
   }
 

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -23,7 +23,6 @@ class _AlbumScreenState extends State<AlbumScreen> {
   Album? _album;
   List<Song> _songs = [];
   bool _isLoading = true;
-  bool _isDownloading = false;
 
   @override
   void initState() {
@@ -89,13 +88,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
     final subsonicService = Provider.of<SubsonicService>(context, listen: false);
     await offlineService.initialize();
 
-    setState(() => _isDownloading = true);
-
-    offlineService
-        .queuePlaylistDownload(_album!.id, _songs, subsonicService)
-        .whenComplete(() {
-      if (mounted) setState(() => _isDownloading = false);
-    });
+    offlineService.queuePlaylistDownload(_album!.id, _songs, subsonicService);
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -260,16 +253,30 @@ class _AlbumScreenState extends State<AlbumScreen> {
                 ),
                 actions: [
                   if (!isOffline)
-                    IconButton(
-                      tooltip: 'Download album',
-                      onPressed: _isDownloading ? null : _downloadAlbum,
-                      icon: _isDownloading
-                          ? const SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Icon(CupertinoIcons.cloud_download),
+                    ValueListenableBuilder<Set<String>>(
+                      valueListenable: OfflineService().queuedPlaylistIds,
+                      builder: (context, queued, _) {
+                        return ValueListenableBuilder<Set<String>>(
+                          valueListenable: OfflineService().downloadedSongIds,
+                          builder: (context, downloaded, _) {
+                            final allDownloaded = _songs.isNotEmpty &&
+                                _songs.every((s) => downloaded.contains(s.id));
+                            final isQueued = queued.contains(_album!.id);
+                            final isSpinning = isQueued && !allDownloaded;
+                            return IconButton(
+                              tooltip: isSpinning ? 'Downloading…' : 'Download album',
+                              onPressed: isSpinning ? null : _downloadAlbum,
+                              icon: isSpinning
+                                  ? const SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(strokeWidth: 2),
+                                    )
+                                  : const Icon(CupertinoIcons.cloud_download),
+                            );
+                          },
+                        );
+                      },
                     ),
                 ],
               ),

--- a/lib/screens/download_playlist_status_screen.dart
+++ b/lib/screens/download_playlist_status_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import '../providers/library_provider.dart';
+import '../services/offline_service.dart';
+import '../theme/app_theme.dart';
+import '../widgets/widgets.dart';
+
+class DownloadPlaylistStatusScreen extends StatelessWidget {
+  const DownloadPlaylistStatusScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final libraryProvider = Provider.of<LibraryProvider>(context);
+    final playlists = libraryProvider.playlists;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Playlist Downloads'),
+        leading: IconButton(
+          icon: const Icon(CupertinoIcons.back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: ValueListenableBuilder<Set<String>>(
+        valueListenable: OfflineService().downloadedSongIds,
+        builder: (context, ids, _) {
+          if (playlists.isEmpty) {
+            return const Center(child: Text('No playlists found'));
+          }
+          return ListView.builder(
+            itemCount: playlists.length,
+            itemBuilder: (context, index) {
+              final playlist = playlists[index];
+              final songs = playlist.songs;
+              final total = songs?.length ?? playlist.songCount ?? 0;
+              final downloaded = songs != null
+                  ? songs.where((s) => ids.contains(s.id)).length
+                  : 0;
+              final allDownloaded = total > 0 && downloaded == total;
+              final hasSongs = songs != null;
+
+              return ListTile(
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                leading: Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: AppTheme.appleMusicRed.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: playlist.coverArt != null
+                      ? AlbumArtwork(
+                          coverArt: playlist.coverArt,
+                          size: 48,
+                          borderRadius: 8,
+                        )
+                      : const Icon(
+                          CupertinoIcons.music_note_list,
+                          color: AppTheme.appleMusicRed,
+                          size: 24,
+                        ),
+                ),
+                title: Text(
+                  playlist.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                trailing: hasSongs
+                    ? Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            '$downloaded / $total',
+                            style: TextStyle(
+                              fontSize: 14,
+                              color: allDownloaded
+                                  ? Colors.green
+                                  : downloaded > 0
+                                      ? Colors.orange
+                                      : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+                              fontWeight: allDownloaded
+                                  ? FontWeight.w600
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                          if (allDownloaded) ...[
+                            const SizedBox(width: 6),
+                            const Icon(Icons.check_circle,
+                                color: Colors.green, size: 18),
+                          ],
+                        ],
+                      )
+                    : Text(
+                        '$total songs',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.5),
+                        ),
+                      ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -17,6 +17,7 @@ import 'library_search_delegate.dart';
 import 'artist_screen.dart';
 import 'radio_screen.dart';
 import '../l10n/app_localizations.dart';
+import '../services/offline_service.dart';
 import '../widgets/album_artwork.dart' show isLocalFilePath;
 
 class LibraryScreen extends StatefulWidget {
@@ -431,6 +432,42 @@ class _LibraryScreenState extends State<LibraryScreen> {
                 ],
               ),
             ),
+            if (item.type == 'Playlist')
+              ValueListenableBuilder<Set<String>>(
+                valueListenable: OfflineService().downloadedSongIds,
+                builder: (context, ids, _) {
+                  return ValueListenableBuilder<Set<String>>(
+                    valueListenable: OfflineService().queuedPlaylistIds,
+                    builder: (context, queued, _) {
+                      final playlists = Provider.of<LibraryProvider>(
+                        context,
+                        listen: false,
+                      ).playlists;
+                      final playlist = playlists.cast().firstWhere(
+                        (p) => p.id == item.id,
+                        orElse: () => null,
+                      );
+                      final songs = playlist?.songs;
+                      final allDownloaded = songs != null &&
+                          songs.isNotEmpty &&
+                          songs.every((s) => ids.contains(s.id));
+                      if (allDownloaded) {
+                        return const Padding(
+                          padding: EdgeInsets.only(left: 8),
+                          child: Icon(Icons.check_circle, color: Colors.green, size: 18),
+                        );
+                      }
+                      if (queued.contains(item.id)) {
+                        return const Padding(
+                          padding: EdgeInsets.only(left: 8),
+                          child: Icon(Icons.check_circle_outline, color: Colors.green, size: 18),
+                        );
+                      }
+                      return const SizedBox.shrink();
+                    },
+                  );
+                },
+              ),
           ],
         ),
       ),

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -28,10 +28,37 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
   bool _isSelecting = false;
   final Set<int> _selectedIndices = {};
 
+  bool _allDownloaded = false;
+  bool _isQueued = false;
+
   @override
   void initState() {
     super.initState();
     _loadPlaylist();
+    OfflineService().downloadedSongIds.addListener(_updateDownloadState);
+    OfflineService().queuedPlaylistIds.addListener(_updateDownloadState);
+  }
+
+  @override
+  void dispose() {
+    OfflineService().downloadedSongIds.removeListener(_updateDownloadState);
+    OfflineService().queuedPlaylistIds.removeListener(_updateDownloadState);
+    super.dispose();
+  }
+
+  void _updateDownloadState() {
+    if (!mounted) return;
+    final songs = _playlist?.songs ?? [];
+    if (songs.isEmpty) return;
+    final ids = OfflineService().downloadedSongIds.value;
+    final allDown = songs.every((s) => ids.contains(s.id));
+    final queued = OfflineService().queuedPlaylistIds.value.contains(widget.playlistId);
+    if (allDown != _allDownloaded || queued != _isQueued) {
+      setState(() {
+        _allDownloaded = allDown;
+        _isQueued = queued;
+      });
+    }
   }
 
   Future<void> _loadPlaylist() async {
@@ -47,6 +74,7 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
           _playlist = playlist;
           _isLoading = false;
         });
+        _updateDownloadState();
       }
     } catch (e) {
       if (mounted) {
@@ -210,21 +238,70 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
   Future<void> _downloadPlaylist() async {
     final songs = _playlist?.songs;
     if (songs == null || songs.isEmpty) return;
-
     final offlineService = OfflineService();
     final subsonicService = Provider.of<SubsonicService>(context, listen: false);
     await offlineService.initialize();
-
     offlineService.queuePlaylistDownload(widget.playlistId, songs, subsonicService);
-
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Queued ${songs.length} songs from ${_playlist!.name} for download…'),
+          content: Text('Queued ${songs.length} songs for download…'),
           duration: const Duration(seconds: 2),
         ),
       );
     }
+  }
+
+  Future<void> _cancelDownload() async {
+    await OfflineService().cancelPlaylistDownload(widget.playlistId);
+  }
+
+  Future<void> _removeDownloads() async {
+    final songs = _playlist?.songs ?? [];
+    if (songs.isEmpty) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Remove downloads?'),
+        content: Text('Remove all ${songs.length} downloaded songs from "${_playlist!.name}"?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Remove', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      await OfflineService().deletePlaylistDownloads(songs.map((s) => s.id).toList());
+    }
+  }
+
+  Widget _buildDownloadButton(BuildContext context) {
+    if (_allDownloaded) {
+      return IconButton(
+        tooltip: 'Downloaded — tap to remove',
+        onPressed: _removeDownloads,
+        icon: const Icon(Icons.cloud_done, color: Colors.green),
+      );
+    }
+    if (_isQueued) {
+      return IconButton(
+        tooltip: 'Downloading — tap to cancel',
+        onPressed: _cancelDownload,
+        icon: const SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return IconButton(
+      tooltip: 'Download playlist',
+      onPressed: _downloadPlaylist,
+      icon: const Icon(CupertinoIcons.cloud_download),
+    );
   }
 
   @override
@@ -289,33 +366,7 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
               icon: const Icon(CupertinoIcons.checkmark_circle),
               onPressed: _toggleSelectMode,
             ),
-            if (!isOffline)
-              ValueListenableBuilder<Set<String>>(
-                valueListenable: OfflineService().queuedPlaylistIds,
-                builder: (context, queued, _) {
-                  return ValueListenableBuilder<Set<String>>(
-                    valueListenable: OfflineService().downloadedSongIds,
-                    builder: (context, downloaded, _) {
-                      final songs = _playlist?.songs ?? [];
-                      final allDownloaded = songs.isNotEmpty &&
-                          songs.every((s) => downloaded.contains(s.id));
-                      final isQueued = queued.contains(widget.playlistId);
-                      final isSpinning = isQueued && !allDownloaded;
-                      return IconButton(
-                        tooltip: isSpinning ? 'Downloading…' : 'Download playlist',
-                        onPressed: isSpinning ? null : _downloadPlaylist,
-                        icon: isSpinning
-                            ? const SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : const Icon(CupertinoIcons.cloud_download),
-                      );
-                    },
-                  );
-                },
-              ),
+            if (!isOffline) _buildDownloadButton(context),
           ],
         ],
       ),

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -330,24 +330,52 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
             padding: const EdgeInsets.all(16),
             child: Column(
               children: [
-                Container(
-                  width: 150,
-                  height: 150,
-                  decoration: BoxDecoration(
-                    color: AppTheme.appleMusicRed.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: _playlist!.coverArt != null
-                      ? AlbumArtwork(
-                          coverArt: _playlist!.coverArt,
-                          size: 150,
-                          borderRadius: 12,
-                        )
-                      : const Icon(
-                          CupertinoIcons.music_note_list,
-                          color: AppTheme.appleMusicRed,
-                          size: 64,
+                ValueListenableBuilder<Set<String>>(
+                  valueListenable: OfflineService().downloadedSongIds,
+                  builder: (context, ids, _) {
+                    final songs = _playlist!.songs ?? [];
+                    final allDownloaded = songs.isNotEmpty &&
+                        songs.every((s) => ids.contains(s.id));
+                    return Stack(
+                      children: [
+                        Container(
+                          width: 150,
+                          height: 150,
+                          decoration: BoxDecoration(
+                            color: AppTheme.appleMusicRed.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: _playlist!.coverArt != null
+                              ? AlbumArtwork(
+                                  coverArt: _playlist!.coverArt,
+                                  size: 150,
+                                  borderRadius: 12,
+                                )
+                              : const Icon(
+                                  CupertinoIcons.music_note_list,
+                                  color: AppTheme.appleMusicRed,
+                                  size: 64,
+                                ),
                         ),
+                        if (allDownloaded)
+                          Positioned(
+                            bottom: 6,
+                            right: 6,
+                            child: Container(
+                              decoration: const BoxDecoration(
+                                color: Colors.white,
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Icon(
+                                Icons.check_circle,
+                                color: Colors.green,
+                                size: 24,
+                              ),
+                            ),
+                          ),
+                      ],
+                    );
+                  },
                 ),
                 const SizedBox(height: 16),
                 Text(

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -50,9 +50,26 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
     if (!mounted) return;
     final songs = _playlist?.songs ?? [];
     if (songs.isEmpty) return;
-    final ids = OfflineService().downloadedSongIds.value;
-    final allDown = songs.every((s) => ids.contains(s.id));
-    final queued = OfflineService().queuedPlaylistIds.value.contains(widget.playlistId);
+    final offline = OfflineService();
+    final ids = offline.downloadedSongIds.value;
+    bool allDown = songs.every((s) => ids.contains(s.id));
+    final queued = offline.queuedPlaylistIds.value.contains(widget.playlistId);
+    // Reactive set can lag behind disk after a download completes — verify directly,
+    // but only on the queued→not-queued transition to avoid per-song disk I/O for
+    // every open screen while something else is downloading.
+    if (!allDown && !queued && _isQueued) {
+      allDown = songs.every((s) => offline.isSongDownloaded(s.id));
+      if (allDown) {
+        final missing = songs
+            .where((s) => !ids.contains(s.id))
+            .map((s) => s.id)
+            .toSet();
+        if (missing.isNotEmpty) {
+          offline.downloadedSongIds.value = {...ids, ...missing};
+          return; // listener will re-fire with the corrected set
+        }
+      }
+    }
     if (allDown != _allDownloaded || queued != _isQueued) {
       setState(() {
         _allDownloaded = allDown;
@@ -274,7 +291,7 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
       ),
     );
     if (confirmed == true && mounted) {
-      await OfflineService().deletePlaylistDownloads(songs.map((s) => s.id).toList());
+      await OfflineService().deletePlaylistDownloads(songs);
     }
   }
 

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -25,7 +25,6 @@ class PlaylistScreen extends StatefulWidget {
 class _PlaylistScreenState extends State<PlaylistScreen> {
   Playlist? _playlist;
   bool _isLoading = true;
-  bool _isDownloading = false;
   bool _isSelecting = false;
   final Set<int> _selectedIndices = {};
 
@@ -216,13 +215,7 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
     final subsonicService = Provider.of<SubsonicService>(context, listen: false);
     await offlineService.initialize();
 
-    setState(() => _isDownloading = true);
-
-    offlineService
-        .queuePlaylistDownload(widget.playlistId, songs, subsonicService)
-        .whenComplete(() {
-      if (mounted) setState(() => _isDownloading = false);
-    });
+    offlineService.queuePlaylistDownload(widget.playlistId, songs, subsonicService);
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -297,16 +290,31 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
               onPressed: _toggleSelectMode,
             ),
             if (!isOffline)
-              IconButton(
-                tooltip: 'Download playlist',
-                onPressed: _isDownloading ? null : _downloadPlaylist,
-                icon: _isDownloading
-                    ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(CupertinoIcons.cloud_download),
+              ValueListenableBuilder<Set<String>>(
+                valueListenable: OfflineService().queuedPlaylistIds,
+                builder: (context, queued, _) {
+                  return ValueListenableBuilder<Set<String>>(
+                    valueListenable: OfflineService().downloadedSongIds,
+                    builder: (context, downloaded, _) {
+                      final songs = _playlist?.songs ?? [];
+                      final allDownloaded = songs.isNotEmpty &&
+                          songs.every((s) => downloaded.contains(s.id));
+                      final isQueued = queued.contains(widget.playlistId);
+                      final isSpinning = isQueued && !allDownloaded;
+                      return IconButton(
+                        tooltip: isSpinning ? 'Downloading…' : 'Download playlist',
+                        onPressed: isSpinning ? null : _downloadPlaylist,
+                        icon: isSpinning
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(CupertinoIcons.cloud_download),
+                      );
+                    },
+                  );
+                },
               ),
           ],
         ],

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -212,31 +212,35 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
     final songs = _playlist?.songs;
     if (songs == null || songs.isEmpty) return;
 
+    final offlineService = OfflineService();
+    if (offlineService.isBackgroundDownloadActive) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('A download is already in progress'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+
     final subsonicService = Provider.of<SubsonicService>(
       context,
       listen: false,
     );
-    final offlineService = OfflineService();
     await offlineService.initialize();
 
     setState(() => _isDownloading = true);
 
-    offlineService.startBackgroundDownload(songs, subsonicService).then((_) {
-      if (mounted) {
-        setState(() => _isDownloading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Downloaded ${songs.length} songs from ${_playlist!.name}'),
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
+    offlineService.startBackgroundDownload(songs, subsonicService).whenComplete(() {
+      if (mounted) setState(() => _isDownloading = false);
     });
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Downloading ${songs.length} songs in background…'),
+          content: Text('Downloading ${songs.length} songs from ${_playlist!.name} in background…'),
           duration: const Duration(seconds: 2),
         ),
       );

--- a/lib/screens/playlist_screen.dart
+++ b/lib/screens/playlist_screen.dart
@@ -213,34 +213,21 @@ class _PlaylistScreenState extends State<PlaylistScreen> {
     if (songs == null || songs.isEmpty) return;
 
     final offlineService = OfflineService();
-    if (offlineService.isBackgroundDownloadActive) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('A download is already in progress'),
-            duration: Duration(seconds: 2),
-          ),
-        );
-      }
-      return;
-    }
-
-    final subsonicService = Provider.of<SubsonicService>(
-      context,
-      listen: false,
-    );
+    final subsonicService = Provider.of<SubsonicService>(context, listen: false);
     await offlineService.initialize();
 
     setState(() => _isDownloading = true);
 
-    offlineService.startBackgroundDownload(songs, subsonicService).whenComplete(() {
+    offlineService
+        .queuePlaylistDownload(widget.playlistId, songs, subsonicService)
+        .whenComplete(() {
       if (mounted) setState(() => _isDownloading = false);
     });
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Downloading ${songs.length} songs from ${_playlist!.name} in background…'),
+          content: Text('Queued ${songs.length} songs from ${_playlist!.name} for download…'),
           duration: const Duration(seconds: 2),
         ),
       );

--- a/lib/screens/playlists_screen.dart
+++ b/lib/screens/playlists_screen.dart
@@ -213,21 +213,25 @@ class _PlaylistTile extends StatelessWidget {
       trailing: ValueListenableBuilder<Set<String>>(
         valueListenable: OfflineService().downloadedSongIds,
         builder: (context, ids, _) {
-          final songs = playlist.songs;
-          final allDownloaded = songs != null &&
-              songs.isNotEmpty &&
-              songs.every((s) => ids.contains(s.id));
-          if (allDownloaded) {
-            return const Icon(
-              Icons.check_circle,
-              size: 20,
-              color: Colors.green,
-            );
-          }
-          return const Icon(
-            CupertinoIcons.chevron_right,
-            size: 18,
-            color: AppTheme.lightSecondaryText,
+          return ValueListenableBuilder<Set<String>>(
+            valueListenable: OfflineService().queuedPlaylistIds,
+            builder: (context, queued, _) {
+              final songs = playlist.songs;
+              final allDownloaded = songs != null &&
+                  songs.isNotEmpty &&
+                  songs.every((s) => ids.contains(s.id));
+              if (allDownloaded) {
+                return const Icon(Icons.check_circle, size: 20, color: Colors.green);
+              }
+              if (queued.contains(playlist.id)) {
+                return const Icon(Icons.check_circle_outline, size: 20, color: Colors.green);
+              }
+              return const Icon(
+                CupertinoIcons.chevron_right,
+                size: 18,
+                color: AppTheme.lightSecondaryText,
+              );
+            },
           );
         },
       ),

--- a/lib/screens/playlists_screen.dart
+++ b/lib/screens/playlists_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import '../models/models.dart';
 import '../providers/providers.dart';
+import '../services/offline_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/widgets.dart';
 import 'playlist_screen.dart';
@@ -209,10 +210,26 @@ class _PlaylistTile extends StatelessWidget {
         '${playlist.songCount ?? 0} songs',
         style: theme.textTheme.bodySmall,
       ),
-      trailing: const Icon(
-        CupertinoIcons.chevron_right,
-        size: 18,
-        color: AppTheme.lightSecondaryText,
+      trailing: ValueListenableBuilder<Set<String>>(
+        valueListenable: OfflineService().downloadedSongIds,
+        builder: (context, ids, _) {
+          final songs = playlist.songs;
+          final allDownloaded = songs != null &&
+              songs.isNotEmpty &&
+              songs.every((s) => ids.contains(s.id));
+          if (allDownloaded) {
+            return const Icon(
+              Icons.check_circle,
+              size: 20,
+              color: Colors.green,
+            );
+          }
+          return const Icon(
+            CupertinoIcons.chevron_right,
+            size: 18,
+            color: AppTheme.lightSecondaryText,
+          );
+        },
       ),
       onTap: onTap,
       onLongPress: onLongPress,

--- a/lib/screens/settings_storage_tab.dart
+++ b/lib/screens/settings_storage_tab.dart
@@ -9,6 +9,7 @@ import '../services/bpm_analyzer_service.dart';
 import '../services/cache_settings_service.dart';
 import '../services/offline_service.dart';
 import '../theme/app_theme.dart';
+import 'download_playlist_status_screen.dart';
 
 class SettingsStorageTab extends StatefulWidget {
   const SettingsStorageTab({super.key});
@@ -403,8 +404,11 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
             ),
           ),
           trailing: const Icon(CupertinoIcons.chevron_right, size: 16),
-          // Navigation wired up in feature/download-detail-screens
-          onTap: null,
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => const DownloadPlaylistStatusScreen(),
+            ),
+          ),
         );
       },
     );

--- a/lib/screens/settings_storage_tab.dart
+++ b/lib/screens/settings_storage_tab.dart
@@ -128,6 +128,10 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
           children: [
             _buildOfflineInfo(),
             _buildDivider(),
+            _buildActiveDownloadsRow(),
+            _buildDivider(),
+            _buildPlaylistStatusRow(),
+            _buildDivider(),
             _buildDownloadAllLibraryButton(),
             _buildDivider(),
             _buildDeleteDownloadsButton(),
@@ -318,6 +322,91 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
               : AppTheme.lightSecondaryText,
         ),
       ),
+    );
+  }
+
+  Widget _buildActiveDownloadsRow() {
+    return ValueListenableBuilder<DownloadState>(
+      valueListenable: _offlineService.downloadState,
+      builder: (context, state, _) {
+        final subtitle = state.isDownloading && state.currentSong != null
+            ? '${state.currentSong!.artist ?? ''} – ${state.currentSong!.title}  (${state.currentProgress}/${state.totalCount})'
+            : state.isDownloading
+                ? '${state.currentProgress}/${state.totalCount}'
+                : 'No downloads in progress';
+        return ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          leading: Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: state.isDownloading
+                    ? const [Color(0xFF34C759), Color(0xFF30D158)]
+                    : const [Color(0xFF8E8E93), Color(0xFFAEAEB2)],
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              state.isDownloading
+                  ? CupertinoIcons.arrow_down_circle_fill
+                  : CupertinoIcons.arrow_down_circle,
+              color: Colors.white,
+              size: 18,
+            ),
+          ),
+          title: const Text('Active Downloads', style: TextStyle(fontSize: 16)),
+          subtitle: Text(
+            subtitle,
+            style: TextStyle(
+              fontSize: 12,
+              color: _isDark ? AppTheme.darkSecondaryText : AppTheme.lightSecondaryText,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: const Icon(CupertinoIcons.chevron_right, size: 16),
+          // Navigation wired up in feature/download-detail-screens
+          onTap: null,
+        );
+      },
+    );
+  }
+
+  Widget _buildPlaylistStatusRow() {
+    return ValueListenableBuilder<Set<String>>(
+      valueListenable: _offlineService.downloadedSongIds,
+      builder: (context, ids, _) {
+        return ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          leading: Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                colors: [Color(0xFF5856D6), Color(0xFF7B68EE)],
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Icon(
+              CupertinoIcons.music_note_list,
+              color: Colors.white,
+              size: 18,
+            ),
+          ),
+          title: const Text('Playlist Downloads', style: TextStyle(fontSize: 16)),
+          subtitle: Text(
+            '${ids.length} songs downloaded',
+            style: TextStyle(
+              fontSize: 12,
+              color: _isDark ? AppTheme.darkSecondaryText : AppTheme.lightSecondaryText,
+            ),
+          ),
+          trailing: const Icon(CupertinoIcons.chevron_right, size: 16),
+          // Navigation wired up in feature/download-detail-screens
+          onTap: null,
+        );
+      },
     );
   }
 

--- a/lib/screens/settings_storage_tab.dart
+++ b/lib/screens/settings_storage_tab.dart
@@ -457,7 +457,10 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
 
       if (confirm != true || !mounted) return;
 
-      await _offlineService.startBackgroundDownload(allSongs, subsonicService);
+      // Fire-and-forget: progress is tracked via downloadState ValueNotifier
+      _offlineService.startBackgroundDownload(allSongs, subsonicService).whenComplete(() {
+        if (mounted) _loadOfflineInfo();
+      });
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -466,7 +469,6 @@ class _SettingsStorageTabState extends State<SettingsStorageTab> {
             duration: const Duration(seconds: 2),
           ),
         );
-        await _loadOfflineInfo();
       }
     } catch (e) {
       if (mounted) {

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -41,6 +41,7 @@ class DownloadState {
     int? totalCount,
     int? downloadedCount,
     Song? currentSong,
+    bool clearCurrentSong = false,
     List<Song>? failedSongs,
   }) {
     return DownloadState(
@@ -48,7 +49,7 @@ class DownloadState {
       currentProgress: currentProgress ?? this.currentProgress,
       totalCount: totalCount ?? this.totalCount,
       downloadedCount: downloadedCount ?? this.downloadedCount,
-      currentSong: currentSong ?? this.currentSong,
+      currentSong: clearCurrentSong ? null : (currentSong ?? this.currentSong),
       failedSongs: failedSongs ?? this.failedSongs,
     );
   }
@@ -82,6 +83,23 @@ class OfflineService {
 
   static const String _keyDownloadedSongs = 'offline_downloaded_songs';
   static const String _keyPendingScrobbles = 'pending_scrobbles';
+  static const String _keyExpectedSizes = 'offline_expected_sizes';
+  static const String _keyQueuedPlaylists = 'offline_queued_playlists';
+  static const String _keyQueuedPlaylistData = 'offline_queued_playlist_data';
+
+  Map<String, int> _expectedSizes = {};
+
+  /// Playlist IDs that have been queued for download but aren't fully done.
+  /// Drives the outline-check badge in playlist list views.
+  final ValueNotifier<Set<String>> queuedPlaylistIds = ValueNotifier({});
+
+  /// playlistId → serialised song list, so we can resume without LibraryProvider.
+  Map<String, List<Map<String, dynamic>>> _queuedPlaylistData = {};
+
+  /// Sequential download queue: each entry is (playlistId, songs).
+  final List<({String playlistId, List<Song> songs, SubsonicService service})>
+      _downloadQueue = [];
+  bool _queueProcessorRunning = false;
 
   Future<void> initialize() async {
     _prefs ??= await SharedPreferences.getInstance();
@@ -93,9 +111,144 @@ class OfflineService {
       await offlineDirectory.create(recursive: true);
     }
 
-    // Seed the reactive set from SharedPrefs so existing downloads are visible
-    // immediately without waiting for a background download to run.
-    downloadedSongIds.value = getDownloadedSongIds().toSet();
+    // Load expected sizes map
+    final sizesJson = _prefs?.getString(_keyExpectedSizes);
+    if (sizesJson != null) {
+      try {
+        final raw = json.decode(sizesJson) as Map<String, dynamic>;
+        _expectedSizes = raw.map((k, v) => MapEntry(k, v as int));
+      } catch (_) {}
+    }
+
+    // Seed from SharedPrefs first
+    final prefsIds = getDownloadedSongIds().toSet();
+
+    // Reconcile with disk: any valid .mp3 on disk that isn't in the index
+    // gets added (handles interrupted downloads where file landed but prefs
+    // weren't updated before the app was killed)
+    final diskIds = <String>{};
+    final offDir = Directory(_offlineDir!);
+    if (await offDir.exists()) {
+      await for (final entity in offDir.list()) {
+        if (entity is File && entity.path.endsWith('.mp3')) {
+          final songId = entity.path.split('/').last.replaceAll('.mp3', '');
+          if (_isFileValid(songId, entity)) diskIds.add(songId);
+        }
+      }
+    }
+
+    final merged = {...prefsIds, ...diskIds};
+    if (merged.length != prefsIds.length) {
+      await _prefs?.setStringList(_keyDownloadedSongs, merged.toList());
+    }
+    downloadedSongIds.value = merged;
+
+    // Load queued playlist tracking
+    final queuedIds = _prefs?.getStringList(_keyQueuedPlaylists) ?? [];
+    final queuedDataJson = _prefs?.getString(_keyQueuedPlaylistData);
+    if (queuedDataJson != null) {
+      try {
+        final raw = json.decode(queuedDataJson) as Map<String, dynamic>;
+        _queuedPlaylistData = raw.map(
+          (k, v) => MapEntry(k, (v as List).cast<Map<String, dynamic>>()),
+        );
+      } catch (_) {}
+    }
+    queuedPlaylistIds.value = queuedIds.toSet();
+
+    // Unmark any playlists that are now fully on disk
+    _checkAndUnmarkCompleted(merged);
+  }
+
+  /// Removes playlists from the queued set if all their songs are now present.
+  void _checkAndUnmarkCompleted(Set<String> presentIds) {
+    final nowDone = <String>{};
+    for (final playlistId in queuedPlaylistIds.value) {
+      final data = _queuedPlaylistData[playlistId];
+      if (data == null || data.isEmpty) continue;
+      final songIds = data.map((s) => s['id']?.toString() ?? '').where((id) => id.isNotEmpty);
+      if (songIds.every(presentIds.contains)) nowDone.add(playlistId);
+    }
+    if (nowDone.isEmpty) return;
+    for (final id in nowDone) { _queuedPlaylistData.remove(id); }
+    queuedPlaylistIds.value = queuedPlaylistIds.value.difference(nowDone);
+    _prefs?.setStringList(_keyQueuedPlaylists, queuedPlaylistIds.value.toList());
+    _prefs?.setString(_keyQueuedPlaylistData, json.encode(_queuedPlaylistData));
+  }
+
+  /// Queue a playlist for download. If the processor isn't running, start it.
+  /// Multiple calls stack up and are processed sequentially.
+  Future<void> queuePlaylistDownload(
+    String playlistId,
+    List<Song> songs,
+    SubsonicService subsonicService,
+  ) async {
+    if (_offlineDir == null) await initialize();
+
+    // Persist queued state so outline badge appears immediately
+    _queuedPlaylistData[playlistId] = songs.map((s) => s.toJson()).toList();
+    queuedPlaylistIds.value = {...queuedPlaylistIds.value, playlistId};
+    await _prefs?.setStringList(_keyQueuedPlaylists, queuedPlaylistIds.value.toList());
+    await _prefs?.setString(_keyQueuedPlaylistData, json.encode(_queuedPlaylistData));
+
+    // Filter to only songs that still need downloading
+    final missing = songs.where((s) => !isSongDownloaded(s.id)).toList();
+    if (missing.isEmpty) {
+      _checkAndUnmarkCompleted(downloadedSongIds.value);
+      return;
+    }
+
+    _downloadQueue.add((playlistId: playlistId, songs: missing, service: subsonicService));
+    _startQueueProcessor();
+  }
+
+  void _startQueueProcessor() {
+    if (_queueProcessorRunning) return;
+    _queueProcessorRunning = true;
+    _processQueue();
+  }
+
+  Future<void> _processQueue() async {
+    while (_downloadQueue.isNotEmpty) {
+      final entry = _downloadQueue.removeAt(0);
+      await startBackgroundDownload(entry.songs, entry.service);
+      _checkAndUnmarkCompleted(downloadedSongIds.value);
+    }
+    _queueProcessorRunning = false;
+  }
+
+  /// Called at startup to re-queue any playlists that were interrupted.
+  Future<void> resumeIncompleteDownloads(SubsonicService subsonicService) async {
+    if (_queuedPlaylistData.isEmpty) return;
+    for (final entry in _queuedPlaylistData.entries) {
+      final missing = entry.value
+          .map((s) => Song.fromJson(s))
+          .where((s) => !isSongDownloaded(s.id))
+          .toList();
+      if (missing.isEmpty) continue;
+      _downloadQueue.add((playlistId: entry.key, songs: missing, service: subsonicService));
+    }
+    if (_downloadQueue.isNotEmpty) _startQueueProcessor();
+  }
+
+  /// Returns true if the file on disk is complete.
+  /// Uses the stored expected size when available, falls back to 64 KB floor.
+  bool _isFileValid(String songId, File file) {
+    try {
+      final len = file.lengthSync();
+      final expected = _expectedSizes[songId];
+      if (expected != null && expected > 0) {
+        return len >= expected;
+      }
+      return len >= 65536;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> _persistExpectedSize(String songId, int bytes) async {
+    _expectedSizes[songId] = bytes;
+    await _prefs?.setString(_keyExpectedSizes, json.encode(_expectedSizes));
   }
 
   String _getSongPath(String songId) {
@@ -141,12 +294,7 @@ class OfflineService {
     if (_offlineDir == null) return false;
     final file = File(_getSongPath(songId));
     if (!file.existsSync()) return false;
-    // Treat files under 64 KB as corrupt/partial downloads
-    try {
-      return file.lengthSync() >= 65536;
-    } catch (_) {
-      return false;
-    }
+    return _isFileValid(songId, file);
   }
 
   List<String> getDownloadedSongIds() {
@@ -196,9 +344,16 @@ class OfflineService {
   }) async {
     if (_offlineDir == null) await initialize();
 
+    // Persist expected size before downloading so reconciliation can use it
+    // even if the app is killed mid-download.
+    if (song.size != null && song.size! > 0) {
+      await _persistExpectedSize(song.id, song.size!);
+    }
+
     final filePath = _getSongPath(song.id);
     try {
-      final url = subsonicService.getStreamUrl(song.id);
+      // Use /download (original file, no transcoding) so size matches song.size
+      final url = subsonicService.getDownloadUrl(song.id);
 
       final dio = Dio();
       await dio.download(
@@ -211,6 +366,10 @@ class OfflineService {
         },
       );
 
+      // Validate against stored expected size (or 64 KB floor if unknown)
+      if (!isSongDownloaded(song.id)) {
+        throw Exception('Downloaded file for ${song.id} failed size check');
+      }
       final downloadedIds = getDownloadedSongIds();
       if (!downloadedIds.contains(song.id)) {
         downloadedIds.add(song.id);
@@ -352,13 +511,28 @@ class OfflineService {
       }
     } catch (e) {
       debugPrint('Error during background download: $e');
-    } finally {
-      _isBackgroundDownloadActive = false;
+    }
+
+    // One automatic retry pass for any failed songs
+    final toRetry = List<Song>.from(downloadState.value.failedSongs);
+    if (toRetry.isNotEmpty && _isBackgroundDownloadActive) {
+      debugPrint('Retrying ${toRetry.length} failed song(s)...');
+      final retryFailed = <Song>[];
+      for (final song in toRetry) {
+        if (!_isBackgroundDownloadActive) break;
+        final success = await downloadSong(song, subsonicService);
+        if (!success) retryFailed.add(song);
+      }
       downloadState.value = downloadState.value.copyWith(
-        isDownloading: false,
-        currentSong: null,
+        failedSongs: retryFailed,
       );
     }
+
+    _isBackgroundDownloadActive = false;
+    downloadState.value = downloadState.value.copyWith(
+      isDownloading: false,
+      clearCurrentSong: true,
+    );
   }
 
   void _updateLogEntry(int index, DownloadStatus status) {
@@ -373,7 +547,7 @@ class OfflineService {
     _isBackgroundDownloadActive = false;
     downloadState.value = downloadState.value.copyWith(
       isDownloading: false,
-      currentSong: null,
+      clearCurrentSong: true,
     );
   }
 
@@ -415,6 +589,8 @@ class OfflineService {
       downloadedIds.remove(songId);
       await _prefs?.setStringList(_keyDownloadedSongs, downloadedIds);
       downloadedSongIds.value = {...downloadedSongIds.value}..remove(songId);
+      _expectedSizes.remove(songId);
+      await _prefs?.setString(_keyExpectedSizes, json.encode(_expectedSizes));
 
       return true;
     } catch (e) {
@@ -437,6 +613,13 @@ class OfflineService {
       }
 
       await _prefs?.setStringList(_keyDownloadedSongs, []);
+      await _prefs?.remove(_keyExpectedSizes);
+      await _prefs?.remove(_keyQueuedPlaylists);
+      await _prefs?.remove(_keyQueuedPlaylistData);
+      _expectedSizes = {};
+      _queuedPlaylistData = {};
+      _downloadQueue.clear();
+      queuedPlaylistIds.value = {};
       downloadedSongIds.value = {};
     } catch (e) {
       debugPrint('Error deleting all downloads: $e');

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -263,9 +263,20 @@ class OfflineService {
     return '$_offlineDir/$songId.jpg';
   }
 
+  String _getCoverArtByArtIdPath(String coverArtId) {
+    return '$_offlineDir/art_${coverArtId.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_')}.jpg';
+  }
+
   String? getLocalCoverArtPath(String songId) {
     if (_offlineDir == null) return null;
     final path = _getCoverArtPath(songId);
+    if (File(path).existsSync()) return path;
+    return null;
+  }
+
+  String? getLocalCoverArtPathByCoverArtId(String? coverArtId) {
+    if (_offlineDir == null || coverArtId == null || coverArtId.isEmpty) return null;
+    final path = _getCoverArtByArtIdPath(coverArtId);
     if (File(path).existsSync()) return path;
     return null;
   }
@@ -383,7 +394,13 @@ class OfflineService {
           final coverUrl = subsonicService.getCoverArtUrl(song.coverArt, size: 600);
           if (coverUrl.isNotEmpty) {
             final dioCover = Dio();
-            await dioCover.download(coverUrl, _getCoverArtPath(song.id));
+            final songCoverPath = _getCoverArtPath(song.id);
+            await dioCover.download(coverUrl, songCoverPath);
+            // Also save indexed by coverArt ID so album/playlist views can find it offline
+            final artIdPath = _getCoverArtByArtIdPath(song.coverArt!);
+            if (!File(artIdPath).existsSync()) {
+              await File(songCoverPath).copy(artIdPath);
+            }
           }
         }
       } catch (e) {

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -568,6 +568,22 @@ class OfflineService {
     );
   }
 
+  Future<void> cancelPlaylistDownload(String playlistId) async {
+    _downloadQueue.removeWhere((e) => e.playlistId == playlistId);
+    if (_isBackgroundDownloadActive) cancelBackgroundDownload();
+    queuedPlaylistIds.value = queuedPlaylistIds.value.difference({playlistId});
+    _queuedPlaylistData.remove(playlistId);
+    await _prefs?.setStringList(_keyQueuedPlaylists, queuedPlaylistIds.value.toList());
+    final data = _queuedPlaylistData;
+    await _prefs?.setString(_keyQueuedPlaylistData, json.encode(data));
+  }
+
+  Future<void> deletePlaylistDownloads(List<String> songIds) async {
+    for (final id in songIds) {
+      await deleteSong(id);
+    }
+  }
+
   bool get isBackgroundDownloadActive => _isBackgroundDownloadActive;
 
   Future<void> downloadPlaylist(

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -569,18 +569,37 @@ class OfflineService {
   }
 
   Future<void> cancelPlaylistDownload(String playlistId) async {
+    // Check before removing: if it's still in the queue it hasn't started yet.
+    final wasStillQueued = _downloadQueue.any((e) => e.playlistId == playlistId);
     _downloadQueue.removeWhere((e) => e.playlistId == playlistId);
-    if (_isBackgroundDownloadActive) cancelBackgroundDownload();
+    // Only cancel the active background download when this playlist is the one
+    // currently running (already popped from the queue and in startBackgroundDownload).
+    if (_isBackgroundDownloadActive && !wasStillQueued) {
+      cancelBackgroundDownload();
+    }
     queuedPlaylistIds.value = queuedPlaylistIds.value.difference({playlistId});
     _queuedPlaylistData.remove(playlistId);
     await _prefs?.setStringList(_keyQueuedPlaylists, queuedPlaylistIds.value.toList());
-    final data = _queuedPlaylistData;
-    await _prefs?.setString(_keyQueuedPlaylistData, json.encode(data));
+    await _prefs?.setString(_keyQueuedPlaylistData, json.encode(_queuedPlaylistData));
   }
 
-  Future<void> deletePlaylistDownloads(List<String> songIds) async {
-    for (final id in songIds) {
-      await deleteSong(id);
+  Future<void> deletePlaylistDownloads(List<Song> songs) async {
+    for (final song in songs) {
+      await deleteSong(song.id);
+    }
+    // deleteSong can't reach art_* files (no coverArtId available from songId alone).
+    // Delete them here using the unique coverArtIds in this set of songs.
+    if (_offlineDir == null) return;
+    final coverArtIds = songs
+        .map((s) => s.coverArt)
+        .whereType<String>()
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    for (final artId in coverArtIds) {
+      try {
+        final f = File(_getCoverArtByArtIdPath(artId));
+        if (f.existsSync()) await f.delete();
+      } catch (_) {}
     }
   }
 

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -8,17 +8,31 @@ import '../models/song.dart';
 import '../models/playlist.dart';
 import 'subsonic_service.dart';
 
+enum DownloadStatus { queued, downloading, done, failed }
+
+class DownloadLogEntry {
+  final Song song;
+  final DownloadStatus status;
+  const DownloadLogEntry(this.song, this.status);
+  DownloadLogEntry copyWith({DownloadStatus? status}) =>
+      DownloadLogEntry(song, status ?? this.status);
+}
+
 class DownloadState {
   final bool isDownloading;
   final int currentProgress;
   final int totalCount;
   final int downloadedCount;
+  final Song? currentSong;
+  final List<Song> failedSongs;
 
   DownloadState({
     this.isDownloading = false,
     this.currentProgress = 0,
     this.totalCount = 0,
     this.downloadedCount = 0,
+    this.currentSong,
+    this.failedSongs = const [],
   });
 
   DownloadState copyWith({
@@ -26,12 +40,16 @@ class DownloadState {
     int? currentProgress,
     int? totalCount,
     int? downloadedCount,
+    Song? currentSong,
+    List<Song>? failedSongs,
   }) {
     return DownloadState(
       isDownloading: isDownloading ?? this.isDownloading,
       currentProgress: currentProgress ?? this.currentProgress,
       totalCount: totalCount ?? this.totalCount,
       downloadedCount: downloadedCount ?? this.downloadedCount,
+      currentSong: currentSong ?? this.currentSong,
+      failedSongs: failedSongs ?? this.failedSongs,
     );
   }
 }
@@ -51,6 +69,15 @@ class OfflineService {
   final ValueNotifier<DownloadState> downloadState = ValueNotifier(
     DownloadState(),
   );
+
+  /// Reactive set of song IDs that are confirmed downloaded on disk.
+  /// Widgets can listen to this to show/hide the green checkmark badge.
+  final ValueNotifier<Set<String>> downloadedSongIds = ValueNotifier({});
+
+  /// Per-batch download log, cleared at the start of each batch.
+  /// Used by the Active Downloads detail screen.
+  final ValueNotifier<List<DownloadLogEntry>> downloadLog = ValueNotifier([]);
+
   bool _isBackgroundDownloadActive = false;
 
   static const String _keyDownloadedSongs = 'offline_downloaded_songs';
@@ -65,6 +92,10 @@ class OfflineService {
     if (!await offlineDirectory.exists()) {
       await offlineDirectory.create(recursive: true);
     }
+
+    // Seed the reactive set from SharedPrefs so existing downloads are visible
+    // immediately without waiting for a background download to run.
+    downloadedSongIds.value = getDownloadedSongIds().toSet();
   }
 
   String _getSongPath(String songId) {
@@ -150,6 +181,14 @@ class OfflineService {
     return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB';
   }
 
+  /// Returns (downloaded, total) for a list of songs — used by the
+  /// Playlist Status settings panel.
+  (int, int) getPlaylistDownloadStatus(List<Song> songs) {
+    final ids = downloadedSongIds.value;
+    final downloaded = songs.where((s) => ids.contains(s.id)).length;
+    return (downloaded, songs.length);
+  }
+
   Future<bool> downloadSong(
     Song song,
     SubsonicService subsonicService, {
@@ -177,6 +216,8 @@ class OfflineService {
         downloadedIds.add(song.id);
         await _prefs?.setStringList(_keyDownloadedSongs, downloadedIds);
       }
+      // Notify reactive listeners (SongTile badges, playlist checkmarks)
+      downloadedSongIds.value = {...downloadedSongIds.value, song.id};
 
       try {
         if (song.coverArt != null) {
@@ -253,11 +294,17 @@ class OfflineService {
     _isBackgroundDownloadActive = true;
     final alreadyDownloadedCount = getDownloadedCount();
 
+    // Reset the per-batch log and seed it with queued entries
+    downloadLog.value = songs
+        .map((s) => DownloadLogEntry(s, DownloadStatus.queued))
+        .toList();
+
     downloadState.value = DownloadState(
       isDownloading: true,
       currentProgress: 0,
       totalCount: songs.length,
       downloadedCount: alreadyDownloadedCount,
+      failedSongs: [],
     );
 
     if (_offlineDir == null) await initialize();
@@ -271,18 +318,32 @@ class OfflineService {
         final song = songs[i];
 
         if (isSongDownloaded(song.id)) {
+          _updateLogEntry(i, DownloadStatus.done);
           downloadState.value = downloadState.value.copyWith(
             currentProgress: i + 1,
           );
           continue;
         }
 
+        // Mark as actively downloading
+        _updateLogEntry(i, DownloadStatus.downloading);
+        downloadState.value = downloadState.value.copyWith(
+          currentSong: song,
+        );
+
         final success = await downloadSong(song, subsonicService);
 
+        _updateLogEntry(i, success ? DownloadStatus.done : DownloadStatus.failed);
+
         final newDownloadedCount = getDownloadedCount();
+        final newFailed = success
+            ? downloadState.value.failedSongs
+            : [...downloadState.value.failedSongs, song];
+
         downloadState.value = downloadState.value.copyWith(
           currentProgress: i + 1,
           downloadedCount: newDownloadedCount,
+          failedSongs: newFailed,
         );
 
         if (!success) {
@@ -293,13 +354,27 @@ class OfflineService {
       debugPrint('Error during background download: $e');
     } finally {
       _isBackgroundDownloadActive = false;
-      downloadState.value = downloadState.value.copyWith(isDownloading: false);
+      downloadState.value = downloadState.value.copyWith(
+        isDownloading: false,
+        currentSong: null,
+      );
+    }
+  }
+
+  void _updateLogEntry(int index, DownloadStatus status) {
+    final log = List<DownloadLogEntry>.from(downloadLog.value);
+    if (index < log.length) {
+      log[index] = log[index].copyWith(status: status);
+      downloadLog.value = log;
     }
   }
 
   void cancelBackgroundDownload() {
     _isBackgroundDownloadActive = false;
-    downloadState.value = downloadState.value.copyWith(isDownloading: false);
+    downloadState.value = downloadState.value.copyWith(
+      isDownloading: false,
+      currentSong: null,
+    );
   }
 
   bool get isBackgroundDownloadActive => _isBackgroundDownloadActive;
@@ -339,6 +414,7 @@ class OfflineService {
       final downloadedIds = getDownloadedSongIds();
       downloadedIds.remove(songId);
       await _prefs?.setStringList(_keyDownloadedSongs, downloadedIds);
+      downloadedSongIds.value = {...downloadedSongIds.value}..remove(songId);
 
       return true;
     } catch (e) {
@@ -361,6 +437,7 @@ class OfflineService {
       }
 
       await _prefs?.setStringList(_keyDownloadedSongs, []);
+      downloadedSongIds.value = {};
     } catch (e) {
       debugPrint('Error deleting all downloads: $e');
     }
@@ -429,7 +506,6 @@ class OfflineService {
   }
 
   String getPlayableUrl(Song song, SubsonicService subsonicService) {
-    
     if (song.isLocal == true && song.path != null) {
       return 'file://${song.path}';
     }

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -109,7 +109,13 @@ class OfflineService {
   bool isSongDownloaded(String songId) {
     if (_offlineDir == null) return false;
     final file = File(_getSongPath(songId));
-    return file.existsSync();
+    if (!file.existsSync()) return false;
+    // Treat files under 64 KB as corrupt/partial downloads
+    try {
+      return file.lengthSync() >= 65536;
+    } catch (_) {
+      return false;
+    }
   }
 
   List<String> getDownloadedSongIds() {
@@ -151,9 +157,9 @@ class OfflineService {
   }) async {
     if (_offlineDir == null) await initialize();
 
+    final filePath = _getSongPath(song.id);
     try {
       final url = subsonicService.getStreamUrl(song.id);
-      final filePath = _getSongPath(song.id);
 
       final dio = Dio();
       await dio.download(
@@ -200,6 +206,11 @@ class OfflineService {
       return true;
     } catch (e) {
       debugPrint('Error downloading song: $e');
+      // Remove partial file so isSongDownloaded() doesn't treat it as complete
+      try {
+        final partial = File(filePath);
+        if (partial.existsSync()) await partial.delete();
+      } catch (_) {}
       return false;
     }
   }

--- a/lib/services/subsonic_service.dart
+++ b/lib/services/subsonic_service.dart
@@ -353,6 +353,12 @@ class SubsonicService {
     return '${_config!.normalizedUrl}/rest/getCoverArt?$queryString';
   }
 
+  /// Returns the /download URL for a song — always original file, no transcoding.
+  /// Use this for offline downloads so file size matches song.size exactly.
+  String getDownloadUrl(String songId) {
+    return _buildUrl('download', {'id': songId});
+  }
+
   String getStreamUrl(String songId, {int? maxBitRate, String? format}) {
     final params = <String, String>{'id': songId};
     if (maxBitRate != null) {

--- a/lib/widgets/album_artwork.dart
+++ b/lib/widgets/album_artwork.dart
@@ -190,14 +190,16 @@ class AlbumArtwork extends StatelessWidget {
       );
     }
 
-    final offlinePath = OfflineService().getLocalCoverArtPathByCoverArtId(coverArt);
-    if (offlinePath != null) {
-      return Image.file(
-        File(offlinePath),
-        key: ValueKey('offline_natural_$coverArt'),
-        fit: BoxFit.contain,
-        errorBuilder: (_, _, _) => _buildPlaceholder(isDark),
-      );
+    if (OfflineService().downloadedSongIds.value.isNotEmpty) {
+      final offlinePath = OfflineService().getLocalCoverArtPathByCoverArtId(coverArt);
+      if (offlinePath != null) {
+        return Image.file(
+          File(offlinePath),
+          key: ValueKey('offline_natural_$coverArt'),
+          fit: BoxFit.contain,
+          errorBuilder: (_, _, _) => _buildPlaceholder(isDark),
+        );
+      }
     }
 
     return Builder(
@@ -238,16 +240,18 @@ class AlbumArtwork extends StatelessWidget {
       );
     }
 
-    final offlinePath = OfflineService().getLocalCoverArtPathByCoverArtId(coverArt);
-    if (offlinePath != null) {
-      return Image.file(
-        File(offlinePath),
-        key: ValueKey('offline_$coverArt'),
-        fit: BoxFit.cover,
-        cacheWidth: cacheSize,
-        cacheHeight: cacheSize,
-        errorBuilder: (_, _, _) => _buildPlaceholder(isDark),
-      );
+    if (OfflineService().downloadedSongIds.value.isNotEmpty) {
+      final offlinePath = OfflineService().getLocalCoverArtPathByCoverArtId(coverArt);
+      if (offlinePath != null) {
+        return Image.file(
+          File(offlinePath),
+          key: ValueKey('offline_$coverArt'),
+          fit: BoxFit.cover,
+          cacheWidth: cacheSize,
+          cacheHeight: cacheSize,
+          errorBuilder: (_, _, _) => _buildPlaceholder(isDark),
+        );
+      }
     }
 
     return Builder(

--- a/lib/widgets/album_artwork.dart
+++ b/lib/widgets/album_artwork.dart
@@ -4,6 +4,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:provider/provider.dart';
 import '../services/subsonic_service.dart';
 import '../services/player_ui_settings_service.dart';
+import '../services/offline_service.dart';
 
 bool isLocalFilePath(String? s) {
   if (s == null || s.isEmpty) return false;
@@ -189,6 +190,16 @@ class AlbumArtwork extends StatelessWidget {
       );
     }
 
+    final offlinePath = OfflineService().getLocalCoverArtPathByCoverArtId(coverArt);
+    if (offlinePath != null) {
+      return Image.file(
+        File(offlinePath),
+        key: ValueKey('offline_natural_$coverArt'),
+        fit: BoxFit.contain,
+        errorBuilder: (_, _, _) => _buildPlaceholder(isDark),
+      );
+    }
+
     return Builder(
       builder: (context) {
         final imageUrl = _ImageUrlCache.getUrl(
@@ -220,6 +231,18 @@ class AlbumArtwork extends StatelessWidget {
       return Image.file(
         artFile,
         key: ValueKey(coverArt),
+        fit: BoxFit.cover,
+        cacheWidth: cacheSize,
+        cacheHeight: cacheSize,
+        errorBuilder: (_, _, _) => _buildPlaceholder(isDark),
+      );
+    }
+
+    final offlinePath = OfflineService().getLocalCoverArtPathByCoverArtId(coverArt);
+    if (offlinePath != null) {
+      return Image.file(
+        File(offlinePath),
+        key: ValueKey('offline_$coverArt'),
         fit: BoxFit.cover,
         cacheWidth: cacheSize,
         cacheHeight: cacheSize,

--- a/lib/widgets/song_tile.dart
+++ b/lib/widgets/song_tile.dart
@@ -182,31 +182,42 @@ class SongTile extends StatelessWidget {
   }
 
   Widget _buildTrailing(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (song.starred == true)
-          Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Icon(
-              CupertinoIcons.heart_fill,
-              size: 14,
-              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.7),
+    return ValueListenableBuilder<Set<String>>(
+      valueListenable: OfflineService().downloadedSongIds,
+      builder: (context, ids, _) {
+        final isDownloaded = ids.contains(song.id);
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isDownloaded)
+              const Padding(
+                padding: EdgeInsets.only(right: 4),
+                child: Icon(Icons.check_circle, size: 14, color: Colors.green),
+              ),
+            if (song.starred == true)
+              Padding(
+                padding: const EdgeInsets.only(right: 4),
+                child: Icon(
+                  CupertinoIcons.heart_fill,
+                  size: 14,
+                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.7),
+                ),
+              ),
+            if (showDuration)
+              Text(
+                song.formattedDuration,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.more_horiz),
+              iconSize: 20,
+              color: Theme.of(context).textTheme.bodySmall?.color,
+              onPressed: () => _showOptions(context),
             ),
-          ),
-        if (showDuration)
-          Text(
-            song.formattedDuration,
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-        const SizedBox(width: 8),
-        IconButton(
-          icon: const Icon(Icons.more_horiz),
-          iconSize: 20,
-          color: Theme.of(context).textTheme.bodySmall?.color,
-          onPressed: () => _showOptions(context),
-        ),
-      ],
+          ],
+        );
+      },
     );
   }
 


### PR DESCRIPTION
> ⚠️ Personal fork feature — totally fine to close this. It's opinionated in presentation and I know it may not fit the project's direction. Sharing in case any of it is useful.

## What this adds

Full offline download workflow for playlists and albums:

- **Download button** in playlist and album action bars (hidden in offline mode)
- **3-state button**: cloud icon (idle) → animated spinner (downloading, tap to cancel) → green `cloud_done` (complete, tap to remove)
- **Cancel mid-download**: removes from queue if not yet started; stops the active download if already running — without affecting other queued playlists
- **Remove downloads**: confirmation dialog, deletes songs + cover art files for the playlist/album
- **Offline album art**: cover art is saved indexed by `coverArt` ID (not just song ID) so `AlbumArtwork` can resolve it in list/grid views when offline
- **Download queue**: multiple playlists/albums queue sequentially; interrupted downloads resume on next app launch
- **Download status screen**: dedicated screen showing per-song progress with queued/downloading/done/failed states
- **Settings storage tab**: "Download All Library" and "Delete All Downloads" controls with size display
- **Song tile badges**: downloaded indicator on song rows
- **Robust validation**: uses `/download` endpoint (no transcoding) and checks `song.size` to detect partial files; 64 KB floor fallback when size is unknown

## What I kept out

- No per-song individual download from song tile long-press (felt like scope creep)
- No background service / foreground notification — downloads run while the app is open
- "Download All Library" and per-playlist queue are separate code paths and will conflict if both run simultaneously (library download silently no-ops if the queue is active) — didn't feel right to redesign the whole thing just to fix that

## Known limitation

If any song permanently fails to download, the spinner stays on that playlist until the app restarts (when `resumeIncompleteDownloads` re-queues only the missing songs). Acceptable tradeoff vs adding a distinct error state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline playlist download queuing with progress tracking
  * New download status monitoring screen for active downloads
  * Download status indicators now display across library, playlists, and individual songs
  * Enhanced player shuffle and repeat mode functionality
  * Automated Android release build system

* **Bug Fixes**
  * Fixed player navigation behavior with shuffle and repeat-all modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dddevid/Musly/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->